### PR TITLE
WIP: feat: add imports to context obj

### DIFF
--- a/packages/analyzer/browser/create.js
+++ b/packages/analyzer/browser/create.js
@@ -1551,8 +1551,8 @@ var analyzer = (function (exports, ts) {
    * Takes a mixinFunctionNode, which is the function/arrow function containing the mixin class
    * and the actual class node returned by the mixin declaration
    */
-  function createMixin(mixinFunctionNode, mixinClassNode, moduleDoc) {
-    let mixinTemplate = createClass(mixinClassNode, moduleDoc);
+  function createMixin(mixinFunctionNode, mixinClassNode, moduleDoc, context) {
+    let mixinTemplate = createClass(mixinClassNode, moduleDoc, context);
 
     mixinTemplate = handleParametersAndReturnType(mixinTemplate, mixinFunctionNode?.declarationList?.declarations?.[0]?.initializer || mixinFunctionNode);
     mixinTemplate = handleJsDoc(mixinTemplate, mixinFunctionNode);

--- a/packages/analyzer/custom-elements.json
+++ b/packages/analyzer/custom-elements.json
@@ -8,21 +8,36 @@
       "declarations": [
         {
           "kind": "function",
-          "name": "AMixin",
-          "parameters": [
-            {
-              "name": "superclass"
-            }
-          ]
+          "name": "bar"
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "AMixin",
+          "name": "bar",
           "declaration": {
-            "name": "AMixin",
+            "name": "bar",
             "module": "fixtures/-default/package/bar.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "fixtures/-default/package/foo.js",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "foo"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "foo",
+          "declaration": {
+            "name": "foo",
+            "module": "fixtures/-default/package/foo.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/-default/package/bar.js
+++ b/packages/analyzer/fixtures/-default/package/bar.js
@@ -1,5 +1,4 @@
-export function AMixin(superclass) {
-  return class A<T, U> extends superclass {
-    t = new C<T, U>();
-  }
+import { named } from 'thirdparty';
+export function bar() {
+
 }

--- a/packages/analyzer/fixtures/-default/package/foo.js
+++ b/packages/analyzer/fixtures/-default/package/foo.js
@@ -1,0 +1,5 @@
+import { named2 } from './local.js';
+import defaultName from 'npm';
+export function foo() {
+
+}

--- a/packages/analyzer/src/features/analyse-phase/classes.js
+++ b/packages/analyzer/src/features/analyse-phase/classes.js
@@ -7,10 +7,10 @@ import { createClass } from './creators/createClass.js';
  */
 export function classPlugin() {
   return {
-    analyzePhase({ts, node, moduleDoc}){
+    analyzePhase({ts, node, moduleDoc, context}){
       switch(node.kind) {
         case ts.SyntaxKind.ClassDeclaration:
-          const klass = createClass(node, moduleDoc);
+          const klass = createClass(node, moduleDoc, context);
           moduleDoc.declarations.push(klass);
           break;
       }

--- a/packages/analyzer/src/features/analyse-phase/creators/createClass.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/createClass.js
@@ -10,7 +10,7 @@ import { hasAttrAnnotation, isDispatchEvent, isPrimitive, isProperty, isReturnSt
 /**
  * Creates a classDoc
  */
-export function createClass(node, moduleDoc) {
+export function createClass(node, moduleDoc, context) {
   const isDefault = hasDefaultModifier(node);
   
   let classTemplate = {
@@ -135,7 +135,7 @@ export function createClass(node, moduleDoc) {
   /**
    * Inheritance
    */
-  classTemplate = handleHeritage(classTemplate, moduleDoc, node);
+  classTemplate = handleHeritage(classTemplate, moduleDoc, context, node);
 
   return classTemplate;
 }

--- a/packages/analyzer/src/features/analyse-phase/creators/createMixin.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/createMixin.js
@@ -6,8 +6,8 @@ import { handleJsDoc } from './handlers.js';
  * Takes a mixinFunctionNode, which is the function/arrow function containing the mixin class
  * and the actual class node returned by the mixin declaration
  */
-export function createMixin(mixinFunctionNode, mixinClassNode, moduleDoc) {
-  let mixinTemplate = createClass(mixinClassNode, moduleDoc);
+export function createMixin(mixinFunctionNode, mixinClassNode, moduleDoc, context) {
+  let mixinTemplate = createClass(mixinClassNode, moduleDoc, context);
 
   mixinTemplate = handleParametersAndReturnType(mixinTemplate, mixinFunctionNode?.declarationList?.declarations?.[0]?.initializer || mixinFunctionNode);
   mixinTemplate = handleJsDoc(mixinTemplate, mixinFunctionNode);

--- a/packages/analyzer/src/features/analyse-phase/creators/handlers.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/handlers.js
@@ -129,10 +129,10 @@ export function handleJsDoc(doc, node) {
 /**
  * Creates a mixin for inside a classDoc
  */
-export function createClassDeclarationMixin(name, moduleDoc) {
+export function createClassDeclarationMixin(name, moduleDoc, context) {
   const mixin = {
     name,
-    ...resolveModuleOrPackageSpecifier(moduleDoc, name)
+    ...resolveModuleOrPackageSpecifier(moduleDoc, context, name)
   };
   return mixin;
 }
@@ -140,7 +140,8 @@ export function createClassDeclarationMixin(name, moduleDoc) {
 /**
  * Handles mixins and superclass
  */
-export function handleHeritage(classTemplate, moduleDoc, node) {
+export function handleHeritage(classTemplate, moduleDoc, context, node) {
+  console.log(1, context)
   node?.heritageClauses?.forEach((clause) => {
     /* Ignoring `ImplementsKeyword` for now, future revisions may retrieve docs per-field for the implemented methods. */
     if (clause.token !== ts.SyntaxKind.ExtendsKeyword) return;
@@ -153,11 +154,11 @@ export function handleHeritage(classTemplate, moduleDoc, node) {
       /* gather mixin calls */
       if (ts.isCallExpression(node)) {
         const mixinName = node.expression.getText();
-        mixins.push(createClassDeclarationMixin(mixinName, moduleDoc))
+        mixins.push(createClassDeclarationMixin(mixinName, moduleDoc, context))
         while (ts.isCallExpression(node.arguments[0])) {
           node = node.arguments[0];
           const mixinName = node.expression.getText();
-          mixins.push(createClassDeclarationMixin(mixinName, moduleDoc));
+          mixins.push(createClassDeclarationMixin(mixinName, moduleDoc, context));
         }
         superClass = node.arguments[0].text;
       } else {

--- a/packages/analyzer/src/features/analyse-phase/custom-elements-define-calls.js
+++ b/packages/analyzer/src/features/analyse-phase/custom-elements-define-calls.js
@@ -10,7 +10,7 @@ import { resolveModuleOrPackageSpecifier } from '../../utils/index.js';
  */
 export function customElementsDefineCallsPlugin() {
   return {
-    analyzePhase({node, moduleDoc}){    
+    analyzePhase({node, moduleDoc, context}){    
 
       /** 
        * @example customElements.define('my-el', MyEl); 
@@ -25,7 +25,7 @@ export function customElementsDefineCallsPlugin() {
           name: elementTag,
           declaration: {
             name: elementClass,
-            ...resolveModuleOrPackageSpecifier(moduleDoc, elementClass)
+            ...resolveModuleOrPackageSpecifier(moduleDoc, context, elementClass)
           },
         };
     

--- a/packages/analyzer/src/features/analyse-phase/mixins.js
+++ b/packages/analyzer/src/features/analyse-phase/mixins.js
@@ -8,7 +8,7 @@ import { createMixin } from './creators/createMixin.js';
  */
 export function mixinPlugin() {
   return {
-    analyzePhase({ts, node, moduleDoc}){
+    analyzePhase({ts, node, moduleDoc, context}){
       switch(node.kind) {
         case ts.SyntaxKind.VariableStatement:
         case ts.SyntaxKind.FunctionDeclaration:
@@ -17,7 +17,7 @@ export function mixinPlugin() {
            */
           if(isMixin(node)) {
             const { mixinFunction, mixinClass } = extractMixinNodes(node);
-            let mixin = createMixin(mixinFunction, mixinClass, moduleDoc);
+            let mixin = createMixin(mixinFunction, mixinClass, moduleDoc, context);
             moduleDoc.declarations.push(mixin);
           }
           break;

--- a/packages/analyzer/src/features/analyse-phase/reexported-wrapped-mixin-exports.js
+++ b/packages/analyzer/src/features/analyse-phase/reexported-wrapped-mixin-exports.js
@@ -19,7 +19,7 @@ import { createClassDeclarationMixin } from './creators/handlers.js';
  */
 export function reexportedWrappedMixinExportsPlugin() {
   return {
-    analyzePhase({ts, node, moduleDoc}){
+    analyzePhase({ts, node, moduleDoc, context}){
       switch(node.kind) {
         case ts.SyntaxKind.VariableStatement:
           if(!isMixin(node)) {
@@ -61,7 +61,7 @@ export function reexportedWrappedMixinExportsPlugin() {
                      * Next, we need to add any other mixins found along the way to the exported mixin's `mixins` array
                      */
                     mixins?.forEach(mixin => {
-                      const newMixin = createClassDeclarationMixin(mixin, moduleDoc);
+                      const newMixin = createClassDeclarationMixin(mixin, moduleDoc, context);
                       foundMixin.mixins = [...(foundMixin?.mixins || []), newMixin];
                     });
 

--- a/packages/analyzer/src/features/framework-plugins/catalyst/controller.js
+++ b/packages/analyzer/src/features/framework-plugins/catalyst/controller.js
@@ -2,7 +2,7 @@ import { toKebabCase, resolveModuleOrPackageSpecifier, decorator } from '../../.
 
 export function controllerPlugin() {
   return {
-    analyzePhase({ts, node, moduleDoc}){
+    analyzePhase({ts, node, moduleDoc, context}){
       switch(node.kind) {
         case ts.SyntaxKind.ClassDeclaration:
           /**
@@ -18,7 +18,7 @@ export function controllerPlugin() {
               name: toKebabCase(className).replace('-element', ''),
               declaration: {
                 name: className,
-                ...resolveModuleOrPackageSpecifier(moduleDoc, className)
+                ...resolveModuleOrPackageSpecifier(moduleDoc, context, className)
               },
             };
 

--- a/packages/analyzer/src/features/framework-plugins/decorators/custom-element-decorator.js
+++ b/packages/analyzer/src/features/framework-plugins/decorators/custom-element-decorator.js
@@ -9,7 +9,7 @@ import { has, decorator, resolveModuleOrPackageSpecifier } from '../../../utils/
  */
 export function customElementDecoratorPlugin() {
   return {
-    analyzePhase({node, moduleDoc}){
+    analyzePhase({node, moduleDoc, context}){
       if(has(node.decorators)) {
         const customElementDecorator = node.decorators?.find(decorator('customElement'));
 
@@ -22,7 +22,7 @@ export function customElementDecoratorPlugin() {
             name: tagName,
             declaration: {
               name: className,
-              ...resolveModuleOrPackageSpecifier(moduleDoc, className)
+              ...resolveModuleOrPackageSpecifier(moduleDoc, context, className)
             },
           };
 

--- a/packages/analyzer/src/features/post-processing/apply-inheritance.js
+++ b/packages/analyzer/src/features/post-processing/apply-inheritance.js
@@ -45,7 +45,7 @@ export function applyInheritancePlugin() {
 
               newItem.inheritedFrom = {
                 name: klass.name,
-                ...resolveModuleOrPackageSpecifier(containingModule, klass.name)
+                ...resolveModuleOrPackageSpecifier(containingModule, context, klass.name)
               }
 
               customElement[type] = [...(customElement[type] || []), newItem];

--- a/packages/analyzer/src/utils/index.js
+++ b/packages/analyzer/src/utils/index.js
@@ -13,8 +13,8 @@ export function isBareModuleSpecifier(specifier) {
   return !!specifier?.replace(/'/g, '')[0].match(/[@a-zA-Z]/g);
 }
 
-export function resolveModuleOrPackageSpecifier(moduleDoc, name) {
-  const foundImport = moduleDoc?.imports?.find(_import => _import.name === name);
+export function resolveModuleOrPackageSpecifier(moduleDoc, context, name) {
+  const foundImport = context?.imports?.find(_import => _import.name === name);
 
   /* item is imported from another file */
   if(foundImport) {


### PR DESCRIPTION
TODO:

```
        Actual:
        --················"module":·"/fixtures/inheritance-mixins/package/ModuleMixin.js"
        Expected:
        ++················"module":·"fixtures/inheritance-mixins/package/ModuleMixin.js"
```

The paths changed for some reason (they now start with a `/` where previously they didnt)