### PR TITLE
Fix(analyzer): Fixes #26: CurrClass conditional chaining in litelement parser

### DIFF
--- a/packages/analyzer/src/features/framework-plugins/lit/static-properties.js
+++ b/packages/analyzer/src/features/framework-plugins/lit/static-properties.js
@@ -39,10 +39,10 @@ export function staticPropertiesPlugin() {
                   if(attributeName) {
                     attribute.name = attributeName;
                   }
-                  currClass.attributes.push(attribute);
+                  currClass?.attributes.push(attribute);
                 }
 
-                currClass.members.push(classMember);
+                currClass?.members.push(classMember);
               });
               return;
             }


### PR DESCRIPTION
In the issue linked is a case where litelement parser crashes on a default export. There are conditional chaining for [this property in other lit files](https://github.com/open-wc/custom-elements-manifest/blob/15a8c6aafcd4f1675fd5c3eaee1c98f543f5867e/packages/analyzer/src/features/framework-plugins/lit/property-decorator.js#L44), and even in [the initializer of the variable](https://github.com/open-wc/custom-elements-manifest/blob/15a8c6aafcd4f1675fd5c3eaee1c98f543f5867e/packages/analyzer/src/features/framework-plugins/lit/static-properties.js#L17), so there should also be ones in the accessors to prevent undefined access