### PR TITLE
feat: include tsx files in default globs

### DIFF
--- a/packages/analyzer/src/utils/cli.js
+++ b/packages/analyzer/src/utils/cli.js
@@ -13,10 +13,10 @@ const IGNORE = [
 ];
 
 export function mergeGlobsAndExcludes(userConfig, cliConfig) {
-  const hasProvidedCliGlobs = cliConfig?.globs?.[0] !== '**/*.{js,ts}' || has(userConfig?.globs);
+  const hasProvidedCliGlobs = cliConfig?.globs?.[0] !== '**/*.{js,ts,tsx}' || has(userConfig?.globs);
 
   if(hasProvidedCliGlobs) {
-    cliConfig.globs = cliConfig?.globs?.filter(glob => glob !== '**/*.{js,ts}');
+    cliConfig.globs = cliConfig?.globs?.filter(glob => glob !== '**/*.{js,ts,tsx}');
   }
 
   const merged = [
@@ -47,7 +47,7 @@ export async function getUserConfig() {
 
 export function getCliConfig(argv) {
   const optionDefinitions = [
-    { name: 'globs', type: String, multiple: true, defaultValue: ['**/*.{js,ts}'] },
+    { name: 'globs', type: String, multiple: true, defaultValue: ['**/*.{js,ts,tsx}'] },
     { name: 'exclude', type: String, multiple: true },
     { name: 'outdir', type: String, defaultValue: '' },
     { name: 'dev', type: Boolean, defaultValue: false },


### PR DESCRIPTION
## Why?

Stencil components are written in .tsx rather than .ts or .js. The current implementation uses the component's type definitions ('dist/types/components/my-component/my-component.d.ts') instead of the source ('src/components/my-component/my-component.tsx'). While this works, there's a drawback in that prop names won't get properly converted to kebab case if an attribute is not set. Stencil's doc gen does this by default so I suspect a lot of Stencil developers aren't manually defining their prop attributes. 

If I have a prop:
```
@Prop() firstName: string;
```

or even

```
@Prop({attribute: 'first-name') firstName: string;
```

and I run `npx @custom-elements-manifest/analyzer analyze --stencil`, my prop will be output as `firstName` instead of the expected `first-name`. 

To get around this, I can use the globs param `npx @custom-elements-manifest/analyzer analyze --stencil --globs 'src/**/*.tsx'` 

## Cons
Stencil is kind of an outlier here so I understand not wanting to change the core in order to cater to one specific framework. In that case, I would recommend just adding some additional clarification in the docs that stencil users need to override the globs. 