### PR TITLE
ensure posix path added to package.json

### DIFF
--- a/packages/analyzer/src/utils/cli.js
+++ b/packages/analyzer/src/utils/cli.js
@@ -106,15 +106,15 @@ export function timestamp() {
 export function addCustomElementsPropertyToPackageJson(outdir) {
   const packageJsonPath = `${process.cwd()}${path.sep}package.json`;
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
-
+  const manifestPath = path.posix.join(outdir, 'custom-elements.json');
   if(packageJson?.customElements) {
-    if(packageJson?.customElements !== path.join(outdir, 'custom-elements.json')) {
-      packageJson.customElements = path.join(outdir, 'custom-elements.json');
+    if(packageJson?.customElements !== manifestPath) {
+      packageJson.customElements = manifestPath;
       fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
     }
     return;
   } else {
-    packageJson.customElements = path.join(outdir, 'custom-elements.json');
+    packageJson.customElements = manifestPath;
     fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
   }
 }


### PR DESCRIPTION
Running the analyser locally on windows with an outdir configured:

`custom-elements-manifest analyze --litelement --globs \"**/*.js\" --outdir \"cem\"`

was replacing the customElements property in package.json with `"customElements": "cem\\custom-elements.json"` instead of `cem/custom-elements.json`.

This adjusts the `addCustomElementsPropertyToPackageJson` function to use `path.posix.join` to ensure it is always written as a posix path. 