### PR TITLE
`--readme` flag

### DIFF
--- a/packages/analyzer/fixtures/cli-readme-flag/README.md
+++ b/packages/analyzer/fixtures/cli-readme-flag/README.md
@@ -1,0 +1,36 @@
+# `my-element.js`:
+
+## class: `MyElement`, `my-element`
+
+### Superclass
+
+| Name          | Module | Package |
+| ------------- | ------ | ------- |
+| `HTMLElement` |        |         |
+
+### Fields
+
+| Name  | Privacy | Type     | Default | Description | Inherited From |
+| ----- | ------- | -------- | ------- | ----------- | -------------- |
+| `foo` |         | `string` | `'bar'` |             |                |
+
+<hr/>
+
+## class: `MyWindow`, `my-window`
+
+### Superclass
+
+| Name          | Module | Package |
+| ------------- | ------ | ------- |
+| `HTMLElement` |        |         |
+
+<hr/>
+
+## Exports
+
+| Kind                        | Name         | Declaration | Module        | Package |
+| --------------------------- | ------------ | ----------- | ------------- | ------- |
+| `custom-element-definition` | `my-foo`     | MyFoo       | /foo.js       |         |
+| `custom-element-definition` | `my-bar`     | MyBar       |               | foo     |
+| `custom-element-definition` | `my-element` | MyElement   | my-element.js |         |
+| `custom-element-definition` | `my-window`  | MyWindow    | my-element.js |         |

--- a/packages/analyzer/fixtures/cli-readme-flag/custom-elements.json
+++ b/packages/analyzer/fixtures/cli-readme-flag/custom-elements.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "field",
+              "name": "foo",
+              "type": {
+                "text": "string"
+              },
+              "default": "'bar'"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-element",
+          "customElement": true
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyWindow",
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-window",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-foo",
+          "declaration": {
+            "name": "MyFoo",
+            "module": "/foo.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "my-bar",
+          "declaration": {
+            "name": "MyBar",
+            "package": "foo"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "my-element",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "my-window",
+          "declaration": {
+            "name": "MyWindow",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/cli-readme-flag/fixture/README.md
+++ b/packages/analyzer/fixtures/cli-readme-flag/fixture/README.md
@@ -1,0 +1,36 @@
+# `my-element.js`:
+
+## class: `MyElement`, `my-element`
+
+### Superclass
+
+| Name          | Module | Package |
+| ------------- | ------ | ------- |
+| `HTMLElement` |        |         |
+
+### Fields
+
+| Name  | Privacy | Type     | Default | Description | Inherited From |
+| ----- | ------- | -------- | ------- | ----------- | -------------- |
+| `foo` |         | `string` | `'bar'` |             |                |
+
+<hr/>
+
+## class: `MyWindow`, `my-window`
+
+### Superclass
+
+| Name          | Module | Package |
+| ------------- | ------ | ------- |
+| `HTMLElement` |        |         |
+
+<hr/>
+
+## Exports
+
+| Kind                        | Name         | Declaration | Module        | Package |
+| --------------------------- | ------------ | ----------- | ------------- | ------- |
+| `custom-element-definition` | `my-foo`     | MyFoo       | /foo.js       |         |
+| `custom-element-definition` | `my-bar`     | MyBar       |               | foo     |
+| `custom-element-definition` | `my-element` | MyElement   | my-element.js |         |
+| `custom-element-definition` | `my-window`  | MyWindow    | my-element.js |         |

--- a/packages/analyzer/fixtures/cli-readme-flag/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/cli-readme-flag/fixture/custom-elements.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "field",
+              "name": "foo",
+              "type": {
+                "text": "string"
+              },
+              "default": "'bar'"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-element",
+          "customElement": true
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyWindow",
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-window",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-foo",
+          "declaration": {
+            "name": "MyFoo",
+            "module": "/foo.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "my-bar",
+          "declaration": {
+            "name": "MyBar",
+            "package": "foo"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "my-element",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "my-window",
+          "declaration": {
+            "name": "MyWindow",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/cli-readme-flag/package/README.md
+++ b/packages/analyzer/fixtures/cli-readme-flag/package/README.md
@@ -1,0 +1,36 @@
+## `my-element.js`:
+
+### class: `MyElement`, `my-element`
+
+#### Superclass
+
+| Name          | Module | Package |
+| ------------- | ------ | ------- |
+| `HTMLElement` |        |         |
+
+#### Fields
+
+| Name  | Privacy | Type     | Default | Description | Inherited From |
+| ----- | ------- | -------- | ------- | ----------- | -------------- |
+| `foo` |         | `string` | `'bar'` |             |                |
+
+<hr/>
+
+### class: `MyWindow`, `my-window`
+
+#### Superclass
+
+| Name          | Module | Package |
+| ------------- | ------ | ------- |
+| `HTMLElement` |        |         |
+
+<hr/>
+
+### Exports
+
+| Kind                        | Name         | Declaration | Module        | Package |
+| --------------------------- | ------------ | ----------- | ------------- | ------- |
+| `custom-element-definition` | `my-foo`     | MyFoo       | /foo.js       |         |
+| `custom-element-definition` | `my-bar`     | MyBar       |               | foo     |
+| `custom-element-definition` | `my-element` | MyElement   | my-element.js |         |
+| `custom-element-definition` | `my-window`  | MyWindow    | my-element.js |         |

--- a/packages/analyzer/fixtures/cli-readme-flag/package/my-element.js
+++ b/packages/analyzer/fixtures/cli-readme-flag/package/my-element.js
@@ -1,0 +1,12 @@
+import {MyFoo} from './foo.js';
+import {MyBar} from 'foo';
+
+class MyElement extends HTMLElement {
+  foo = 'bar';
+}
+class MyWindow extends HTMLElement {}
+
+customElements.define('my-foo', MyFoo);
+customElements.define('my-bar', MyBar);
+customElements.define('my-element', MyElement);
+window.customElements.define('my-window', MyWindow);

--- a/packages/analyzer/fixtures/cli-readme-flag/package/package.json
+++ b/packages/analyzer/fixtures/cli-readme-flag/package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "my-el",
+  "customElements": "../custom-elements.json"
+}

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -43,6 +43,7 @@
     "command-line-args": "^5.1.2",
     "comment-parser": "^1.1.5",
     "custom-elements-manifest": "^1.0.0",
+    "cem-plugin-readme": "0.1.2",
     "debounce": "^1.2.1",
     "globby": "^11.0.4",
     "typescript": "^4.3.2"

--- a/packages/analyzer/src/utils/cli.js
+++ b/packages/analyzer/src/utils/cli.js
@@ -5,10 +5,10 @@ import commandLineArgs from 'command-line-args';
 import { has } from './index.js';
 
 const IGNORE = [
-  '!node_modules/**/*.*', 
-  '!bower_components/**/*.*', 
-  '!**/*.test.{js,ts}', 
-  '!**/*.suite.{js,ts}', 
+  '!node_modules/**/*.*',
+  '!bower_components/**/*.*',
+  '!**/*.test.{js,ts}',
+  '!**/*.suite.{js,ts}',
   '!**/*.config.{js,ts}'
 ];
 
@@ -54,7 +54,11 @@ export const DEFAULTS = {
   litelement: false,
   stencil: false,
   fast: false,
-  catalyst: false
+  catalyst: false,
+  readme: true,
+  header: '',
+  footer: '',
+  headingOffset: 0,
 }
 
 export function getCliConfig(argv) {
@@ -68,8 +72,12 @@ export function getCliConfig(argv) {
     { name: 'stencil', type: Boolean },
     { name: 'fast', type: Boolean },
     { name: 'catalyst', type: Boolean },
+    { name: 'readme', type: Boolean },
+    { name: 'header', type: String },
+    { name: 'footer', type: String },
+    { name: 'headingOffset', type: Number },
   ];
-  
+
   return commandLineArgs(optionDefinitions, { argv });
 }
 
@@ -103,6 +111,22 @@ export function timestamp() {
   return date.toLocaleTimeString();
 }
 
+export async function addReadmePlugin({ readme, ...options }) {
+  if (!readme)
+    return [];
+  else {
+    const { headingOffset, header, footer, outdir } = options;
+    return [
+      await import('cem-plugin-readme').then(m => m.readmePlugin({
+        footer,
+        from: outdir,
+        header,
+        headingOffset,
+      })),
+    ];
+  }
+}
+
 export function addCustomElementsPropertyToPackageJson(outdir) {
   const packageJsonPath = `${process.cwd()}${path.sep}package.json`;
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
@@ -123,18 +147,22 @@ export const MENU = `
 @custom-elements-manifest/analyzer
 
 Available commands:
-    | Command/option   | Type       | Description                                                 | Example               |
-    | ---------------- | ---------- | ----------------------------------------------------------- | --------------------- |
-    | analyze          |            | Analyze your components                                     |                       |
-    | --globs          | string[]   | Globs to analyze                                            | \`--globs "foo.js"\`    |
-    | --exclude        | string[]   | Globs to exclude                                            | \`--exclude "foo.js"\`  |
-    | --outdir         | string     | Directory to output the Manifest to                         | \`--outdir dist\`       |
-    | --watch          | boolean    | Enables watch mode, generates a new manifest on file change | \`--watch\`             |
-    | --dev            | boolean    | Enables extra logging for debugging                         | \`--dev\`               |
-    | --litelement     | boolean    | Enable special handling for LitElement syntax               | \`--litelement\`        |
-    | --fast           | boolean    | Enable special handling for FASTElement syntax              | \`--fast\`              |
-    | --stencil        | boolean    | Enable special handling for Stencil syntax                  | \`--stencil\`           |
-    | --catalyst       | boolean    | Enable special handling for Catalyst syntax                 | \`--catalyst\`          |
+    | Command/option   | Type       | Description                                                 | Example                            |
+    | ---------------- | ---------- | ----------------------------------------------------------- | ---------------------------------- |
+    | analyze          |            | Analyze your components                                     |                                    |
+    | --globs          | string[]   | Globs to analyze                                            | \`--globs "foo.js"\`               |
+    | --exclude        | string[]   | Globs to exclude                                            | \`--exclude "foo.js"\`             |
+    | --outdir         | string     | Directory to output the Manifest to                         | \`--outdir dist\`                  |
+    | --watch          | boolean    | Enables watch mode, generates a new manifest on file change | \`--watch\`                        |
+    | --dev            | boolean    | Enables extra logging for debugging                         | \`--dev\`                          |
+    | --litelement     | boolean    | Enable special handling for LitElement syntax               | \`--litelement\`                   |
+    | --fast           | boolean    | Enable special handling for FASTElement syntax              | \`--fast\`                         |
+    | --stencil        | boolean    | Enable special handling for Stencil syntax                  | \`--stencil\`                      |
+    | --catalyst       | boolean    | Enable special handling for Catalyst syntax                 | \`--catalyst\`                     |
+    | --readme         | boolean    | Create a README.md file                                     | \`--readme\`                       |
+    | --header         | string     | Markdown header file for the README.md                      | \`--header README.head.md\`        |
+    | --footer         | string     | Markdown footer file for the README.md                      | \`--footer README.foot.md\`        |
+    | --headingOffset  | number     | Number of levels to offset headings in the README.md        | \`--headingOffset 1\`              |
 
 Example:
     custom-elements-manifest analyze --litelement --globs "**/*.js" --exclude "foo.js" "bar.js"

--- a/packages/analyzer/test/cli.test.js
+++ b/packages/analyzer/test/cli.test.js
@@ -1,0 +1,55 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import path from 'path';
+import fs from 'fs';
+import * as child_process from 'child_process';
+import { promisify } from 'util'
+
+const exec = promisify(child_process.exec);
+
+const fixturesDir = path.join(process.cwd(), 'fixtures');
+let testCases = fs.readdirSync(fixturesDir).filter(x => x.startsWith('cli-'));
+
+const runSingle = testCases.find(_case => _case.startsWith('+'));
+if (runSingle) {
+  testCases = [runSingle];
+}
+
+testCases.forEach(testCase => {
+  test(`Testcase ${testCase}`, async () => {
+    // skips tests
+    if (testCase.startsWith('-')) {
+      assert.equal(true, true);
+      return;
+    }
+
+    const fixturePath = path.join(fixturesDir, testCase, 'fixture');
+    const fixture = JSON.parse(fs.readFileSync(path.join(fixturePath, 'custom-elements.json'), 'utf-8'));
+
+    const packagePath = path.join(fixturesDir, testCase, 'package');
+
+    const outputPath = path.join(fixturesDir, testCase);
+
+    try {
+      const { stdout, stderr } = await exec('node ../../../index.js analyze --readme --outdir ..', { cwd: packagePath });
+      console.log(stdout)
+      if (stderr)
+        throw new Error(stderr);
+    } catch (e) {
+      console.error(e); // should contain code (exit code) and signal (that caused the termination).
+    }
+
+    const result = JSON.parse(fs.readFileSync(path.join(outputPath, 'custom-elements.json'), 'utf-8'));
+
+    assert.equal(result, fixture);
+
+    if (testCase.includes('readme')) {
+      assert.equal(
+        fs.readFileSync(path.join(outputPath, 'README.md'), 'utf8'),
+        fs.readFileSync(path.join(fixturePath, 'README.md'), 'utf8'),
+      );
+    }
+  });
+});
+
+test.run();

--- a/packages/analyzer/test/integration.test.js
+++ b/packages/analyzer/test/integration.test.js
@@ -9,7 +9,7 @@ import ts from 'typescript';
 import { create } from '../src/create.js';
 
 const fixturesDir = path.join(process.cwd(), 'fixtures');
-let testCases = fs.readdirSync(fixturesDir);
+let testCases = fs.readdirSync(fixturesDir).filter(x => !x.startsWith('cli-'));
 
 const runSingle = testCases.find(_case => _case.startsWith('+'));
 if (runSingle) {
@@ -37,7 +37,7 @@ testCases.forEach(testCase => {
       .map(glob => {
         const relativeModulePath = `.${path.sep}${path.relative(process.cwd(), glob)}`;
         const source = fs.readFileSync(relativeModulePath).toString();
-    
+
         return ts.createSourceFile(
           relativeModulePath,
           source,
@@ -52,12 +52,19 @@ testCases.forEach(testCase => {
       const config = await import(manifestPathFileURL);
       plugins = [...config.default.plugins];
     } catch {}
-    
+
     const result = create({modules, plugins});
 
     fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
 
     assert.equal(result, fixture);
+
+    if (testCase === 'readme-flag')
+      assert.equal(
+        fs.readFileSync(path.join(path.dirname(outputPath), 'README.md')),
+        fs.readFileSync(path.join(path.dirname(fixturePath), 'README.md')),
+        '--readme flag'
+      )
   });
 });
 

--- a/packages/to-markdown/fixtures/css-parts/EXPECTED.md
+++ b/packages/to-markdown/fixtures/css-parts/EXPECTED.md
@@ -4,14 +4,14 @@
 
 ### CSS Parts
 
-| Name | Description     |
-| ---- | --------------- |
-| bar  | the bar element |
+| Name  | Description     |
+| ----- | --------------- |
+| `bar` | the bar element |
 
 <hr/>
 
 ## Exports
 
-| Kind                      | Name       | Declaration | Module                                 | Package |
-| ------------------------- | ---------- | ----------- | -------------------------------------- | ------- |
-| custom-element-definition | my-element | MyElement   | ./fixtures/-TEST/package/my-element.js |         |
+| Kind                        | Name         | Declaration | Module                                 | Package |
+| --------------------------- | ------------ | ----------- | -------------------------------------- | ------- |
+| `custom-element-definition` | `my-element` | MyElement   | ./fixtures/-TEST/package/my-element.js |         |

--- a/packages/to-markdown/fixtures/css-parts/README.md
+++ b/packages/to-markdown/fixtures/css-parts/README.md
@@ -4,14 +4,14 @@
 
 ### CSS Parts
 
-| Name | Description     |
-| ---- | --------------- |
-| bar  | the bar element |
+| Name  | Description     |
+| ----- | --------------- |
+| `bar` | the bar element |
 
 <hr/>
 
 ## Exports
 
-| Kind                      | Name       | Declaration | Module                                 | Package |
-| ------------------------- | ---------- | ----------- | -------------------------------------- | ------- |
-| custom-element-definition | my-element | MyElement   | ./fixtures/-TEST/package/my-element.js |         |
+| Kind                        | Name         | Declaration | Module                                 | Package |
+| --------------------------- | ------------ | ----------- | -------------------------------------- | ------- |
+| `custom-element-definition` | `my-element` | MyElement   | ./fixtures/-TEST/package/my-element.js |         |

--- a/packages/to-markdown/fixtures/details-private/EXPECTED.md
+++ b/packages/to-markdown/fixtures/details-private/EXPECTED.md
@@ -4,31 +4,31 @@
 
 ### Fields
 
-| Name | Privacy | Type       | Default    | Description | Inherited From |
-| ---- | ------- | ---------- | ---------- | ----------- | -------------- |
-| pub  | public  | `'public'` | `'public'` |             |                |
+| Name  | Privacy | Type       | Default    | Description | Inherited From |
+| ----- | ------- | ---------- | ---------- | ----------- | -------------- |
+| `pub` | public  | `'public'` | `'public'` |             |                |
 
 ### Methods
 
-| Name         | Privacy | Description | Parameters | Return | Inherited From |
-| ------------ | ------- | ----------- | ---------- | ------ | -------------- |
-| publicMethod | public  |             |            | `void` |                |
+| Name           | Privacy | Description | Parameters | Return | Inherited From |
+| -------------- | ------- | ----------- | ---------- | ------ | -------------- |
+| `publicMethod` | public  |             |            | `void` |                |
 
 <details><summary>Private API</summary>
 
 ### Fields
 
-| Name | Privacy   | Type          | Default       | Description | Inherited From |
-| ---- | --------- | ------------- | ------------- | ----------- | -------------- |
-| prot | protected | `'protected'` | `'protected'` |             |                |
-| priv | private   | `'private'`   | `'private'`   |             |                |
+| Name   | Privacy   | Type          | Default       | Description | Inherited From |
+| ------ | --------- | ------------- | ------------- | ----------- | -------------- |
+| `prot` | protected | `'protected'` | `'protected'` |             |                |
+| `priv` | private   | `'private'`   | `'private'`   |             |                |
 
 ### Methods
 
-| Name            | Privacy   | Description | Parameters | Return | Inherited From |
-| --------------- | --------- | ----------- | ---------- | ------ | -------------- |
-| protectedMethod | protected |             |            | `void` |                |
-| privateMethod   | private   |             |            | `void` |                |
+| Name              | Privacy   | Description | Parameters | Return | Inherited From |
+| ----------------- | --------- | ----------- | ---------- | ------ | -------------- |
+| `protectedMethod` | protected |             |            | `void` |                |
+| `privateMethod`   | private   |             |            | `void` |                |
 
 </details>
 
@@ -36,6 +36,6 @@
 
 ## Exports
 
-| Kind                      | Name       | Declaration | Module          | Package |
-| ------------------------- | ---------- | ----------- | --------------- | ------- |
-| custom-element-definition | my-element | MyElement   | ./my-element.js |         |
+| Kind                        | Name         | Declaration | Module          | Package |
+| --------------------------- | ------------ | ----------- | --------------- | ------- |
+| `custom-element-definition` | `my-element` | MyElement   | ./my-element.js |         |

--- a/packages/to-markdown/fixtures/details-private/README.md
+++ b/packages/to-markdown/fixtures/details-private/README.md
@@ -4,31 +4,31 @@
 
 ### Fields
 
-| Name | Privacy | Type       | Default    | Description | Inherited From |
-| ---- | ------- | ---------- | ---------- | ----------- | -------------- |
-| pub  | public  | `'public'` | `'public'` |             |                |
+| Name  | Privacy | Type       | Default    | Description | Inherited From |
+| ----- | ------- | ---------- | ---------- | ----------- | -------------- |
+| `pub` | public  | `'public'` | `'public'` |             |                |
 
 ### Methods
 
-| Name         | Privacy | Description | Parameters | Return | Inherited From |
-| ------------ | ------- | ----------- | ---------- | ------ | -------------- |
-| publicMethod | public  |             |            | `void` |                |
+| Name           | Privacy | Description | Parameters | Return | Inherited From |
+| -------------- | ------- | ----------- | ---------- | ------ | -------------- |
+| `publicMethod` | public  |             |            | `void` |                |
 
 <details><summary>Private API</summary>
 
 ### Fields
 
-| Name | Privacy   | Type          | Default       | Description | Inherited From |
-| ---- | --------- | ------------- | ------------- | ----------- | -------------- |
-| prot | protected | `'protected'` | `'protected'` |             |                |
-| priv | private   | `'private'`   | `'private'`   |             |                |
+| Name   | Privacy   | Type          | Default       | Description | Inherited From |
+| ------ | --------- | ------------- | ------------- | ----------- | -------------- |
+| `prot` | protected | `'protected'` | `'protected'` |             |                |
+| `priv` | private   | `'private'`   | `'private'`   |             |                |
 
 ### Methods
 
-| Name            | Privacy   | Description | Parameters | Return | Inherited From |
-| --------------- | --------- | ----------- | ---------- | ------ | -------------- |
-| protectedMethod | protected |             |            | `void` |                |
-| privateMethod   | private   |             |            | `void` |                |
+| Name              | Privacy   | Description | Parameters | Return | Inherited From |
+| ----------------- | --------- | ----------- | ---------- | ------ | -------------- |
+| `protectedMethod` | protected |             |            | `void` |                |
+| `privateMethod`   | private   |             |            | `void` |                |
 
 </details>
 
@@ -36,6 +36,6 @@
 
 ## Exports
 
-| Kind                      | Name       | Declaration | Module          | Package |
-| ------------------------- | ---------- | ----------- | --------------- | ------- |
-| custom-element-definition | my-element | MyElement   | ./my-element.js |         |
+| Kind                        | Name         | Declaration | Module          | Package |
+| --------------------------- | ------------ | ----------- | --------------- | ------- |
+| `custom-element-definition` | `my-element` | MyElement   | ./my-element.js |         |

--- a/packages/to-markdown/fixtures/export-kinds/EXPECTED.md
+++ b/packages/to-markdown/fixtures/export-kinds/EXPECTED.md
@@ -1,0 +1,20 @@
+# `custom-kinds.js`:
+
+## class: `MyElement`, `my-element`
+
+<hr/>
+
+## Variables
+
+| Name | Description | Type      |
+| ---- | ----------- | --------- |
+| `js` |             | `boolean` |
+
+<hr/>
+
+## Exports
+
+| Kind                                                                                                                          | Name        | Declaration | Module                                 | Package |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------- | -------------------------------------- | ------- |
+| ![custom-element-definition](https://raw.githubusercontent.com/webcomponents/webcomponents.org/master/client/assets/logo.svg) | `MyElement` | MyElement   | ./fixtures/-TEST/package/my-element.js |         |
+| JavaScript                                                                                                                    | `js`        | js          | ./fixtures/-TEST/package/my-element.js |         |

--- a/packages/to-markdown/fixtures/export-kinds/README.md
+++ b/packages/to-markdown/fixtures/export-kinds/README.md
@@ -1,0 +1,20 @@
+# `custom-kinds.js`:
+
+## class: `MyElement`, `my-element`
+
+<hr/>
+
+## Variables
+
+| Name | Description | Type      |
+| ---- | ----------- | --------- |
+| `js` |             | `boolean` |
+
+<hr/>
+
+## Exports
+
+| Kind                                                                                                                          | Name        | Declaration | Module                                 | Package |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------- | -------------------------------------- | ------- |
+| ![custom-element-definition](https://raw.githubusercontent.com/webcomponents/webcomponents.org/master/client/assets/logo.svg) | `MyElement` | MyElement   | ./fixtures/-TEST/package/my-element.js |         |
+| JavaScript                                                                                                                    | `js`        | js          | ./fixtures/-TEST/package/my-element.js |         |

--- a/packages/to-markdown/fixtures/export-kinds/custom-elements.json
+++ b/packages/to-markdown/fixtures/export-kinds/custom-elements.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "custom-kinds.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "MyElement",
+          "tagName": "my-element"
+        },
+        {
+          "kind": "variable",
+          "name": "js",
+          "type": {
+            "text": "boolean"
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "MyElement",
+          "declaration": {
+            "name": "MyElement",
+            "module": "./fixtures/-TEST/package/my-element.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "js",
+          "declaration": {
+            "name": "js",
+            "module": "./fixtures/-TEST/package/my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/to-markdown/fixtures/heading-offset-2/EXPECTED.md
+++ b/packages/to-markdown/fixtures/heading-offset-2/EXPECTED.md
@@ -4,41 +4,41 @@
 
 ##### Fields
 
-| Name  | Privacy | Type | Default | Description | Inherited From |
-| ----- | ------- | ---- | ------- | ----------- | -------------- |
-| prop1 | public  |      |         |             |                |
+| Name    | Privacy | Type | Default | Description | Inherited From |
+| ------- | ------- | ---- | ------- | ----------- | -------------- |
+| `prop1` | public  |      |         |             |                |
 
 ##### Methods
 
-| Name           | Privacy | Description                         | Parameters            | Return | Inherited From |
-| -------------- | ------- | ----------------------------------- | --------------------- | ------ | -------------- |
-| instanceMethod | public  | Some description of the method here | `e: Event, a: string` |        |                |
+| Name             | Privacy | Description                         | Parameters            | Return | Inherited From |
+| ---------------- | ------- | ----------------------------------- | --------------------- | ------ | -------------- |
+| `instanceMethod` | public  | Some description of the method here | `e: Event, a: string` |        |                |
 
 ##### Events
 
-| Name     | Type    | Description | Inherited From |
-| -------- | ------- | ----------- | -------------- |
-| my-event | `Event` |             |                |
+| Name       | Type    | Description | Inherited From |
+| ---------- | ------- | ----------- | -------------- |
+| `my-event` | `Event` |             |                |
 
 ##### CSS Properties
 
-| Name               | Default         | Description               |
-| ------------------ | --------------- | ------------------------- |
-| --background-color | `rebeccapurple` | Controls the color of bar |
+| Name                 | Default         | Description               |
+| -------------------- | --------------- | ------------------------- |
+| `--background-color` | `rebeccapurple` | Controls the color of bar |
 
 <hr/>
 
 #### Functions
 
-| Name           | Description               | Parameters              | Return    |
-| -------------- | ------------------------- | ----------------------- | --------- |
-| functionExport | This is a function export | `a: string, b: boolean` | `boolean` |
+| Name             | Description               | Parameters              | Return    |
+| ---------------- | ------------------------- | ----------------------- | --------- |
+| `functionExport` | This is a function export | `a: string, b: boolean` | `boolean` |
 
 <hr/>
 
 #### Exports
 
-| Kind                      | Name           | Declaration    | Module          | Package |
-| ------------------------- | -------------- | -------------- | --------------- | ------- |
-| custom-element-definition | my-element     | MyElement      | ./my-element.js |         |
-| js                        | functionExport | functionExport | ./my-element.js |         |
+| Kind                        | Name             | Declaration    | Module          | Package |
+| --------------------------- | ---------------- | -------------- | --------------- | ------- |
+| `custom-element-definition` | `my-element`     | MyElement      | ./my-element.js |         |
+| `js`                        | `functionExport` | functionExport | ./my-element.js |         |

--- a/packages/to-markdown/fixtures/heading-offset-2/README.md
+++ b/packages/to-markdown/fixtures/heading-offset-2/README.md
@@ -4,41 +4,41 @@
 
 ##### Fields
 
-| Name  | Privacy | Type | Default | Description | Inherited From |
-| ----- | ------- | ---- | ------- | ----------- | -------------- |
-| prop1 | public  |      |         |             |                |
+| Name    | Privacy | Type | Default | Description | Inherited From |
+| ------- | ------- | ---- | ------- | ----------- | -------------- |
+| `prop1` | public  |      |         |             |                |
 
 ##### Methods
 
-| Name           | Privacy | Description                         | Parameters            | Return | Inherited From |
-| -------------- | ------- | ----------------------------------- | --------------------- | ------ | -------------- |
-| instanceMethod | public  | Some description of the method here | `e: Event, a: string` |        |                |
+| Name             | Privacy | Description                         | Parameters            | Return | Inherited From |
+| ---------------- | ------- | ----------------------------------- | --------------------- | ------ | -------------- |
+| `instanceMethod` | public  | Some description of the method here | `e: Event, a: string` |        |                |
 
 ##### Events
 
-| Name     | Type    | Description | Inherited From |
-| -------- | ------- | ----------- | -------------- |
-| my-event | `Event` |             |                |
+| Name       | Type    | Description | Inherited From |
+| ---------- | ------- | ----------- | -------------- |
+| `my-event` | `Event` |             |                |
 
 ##### CSS Properties
 
-| Name               | Default         | Description               |
-| ------------------ | --------------- | ------------------------- |
-| --background-color | `rebeccapurple` | Controls the color of bar |
+| Name                 | Default         | Description               |
+| -------------------- | --------------- | ------------------------- |
+| `--background-color` | `rebeccapurple` | Controls the color of bar |
 
 <hr/>
 
 #### Functions
 
-| Name           | Description               | Parameters              | Return    |
-| -------------- | ------------------------- | ----------------------- | --------- |
-| functionExport | This is a function export | `a: string, b: boolean` | `boolean` |
+| Name             | Description               | Parameters              | Return    |
+| ---------------- | ------------------------- | ----------------------- | --------- |
+| `functionExport` | This is a function export | `a: string, b: boolean` | `boolean` |
 
 <hr/>
 
 #### Exports
 
-| Kind                      | Name           | Declaration    | Module          | Package |
-| ------------------------- | -------------- | -------------- | --------------- | ------- |
-| custom-element-definition | my-element     | MyElement      | ./my-element.js |         |
-| js                        | functionExport | functionExport | ./my-element.js |         |
+| Kind                        | Name             | Declaration    | Module          | Package |
+| --------------------------- | ---------------- | -------------- | --------------- | ------- |
+| `custom-element-definition` | `my-element`     | MyElement      | ./my-element.js |         |
+| `js`                        | `functionExport` | functionExport | ./my-element.js |         |

--- a/packages/to-markdown/fixtures/hide-private/EXPECTED.md
+++ b/packages/to-markdown/fixtures/hide-private/EXPECTED.md
@@ -4,22 +4,22 @@
 
 ### Fields
 
-| Name | Privacy   | Type          | Default       | Description | Inherited From |
-| ---- | --------- | ------------- | ------------- | ----------- | -------------- |
-| pub  | public    | `'public'`    | `'public'`    |             |                |
-| prot | protected | `'protected'` | `'protected'` |             |                |
+| Name   | Privacy   | Type          | Default       | Description | Inherited From |
+| ------ | --------- | ------------- | ------------- | ----------- | -------------- |
+| `pub`  | public    | `'public'`    | `'public'`    |             |                |
+| `prot` | protected | `'protected'` | `'protected'` |             |                |
 
 ### Methods
 
-| Name            | Privacy   | Description | Parameters | Return | Inherited From |
-| --------------- | --------- | ----------- | ---------- | ------ | -------------- |
-| publicMethod    | public    |             |            | `void` |                |
-| protectedMethod | protected |             |            | `void` |                |
+| Name              | Privacy   | Description | Parameters | Return | Inherited From |
+| ----------------- | --------- | ----------- | ---------- | ------ | -------------- |
+| `publicMethod`    | public    |             |            | `void` |                |
+| `protectedMethod` | protected |             |            | `void` |                |
 
 <hr/>
 
 ## Exports
 
-| Kind                      | Name       | Declaration | Module          | Package |
-| ------------------------- | ---------- | ----------- | --------------- | ------- |
-| custom-element-definition | my-element | MyElement   | ./my-element.js |         |
+| Kind                        | Name         | Declaration | Module          | Package |
+| --------------------------- | ------------ | ----------- | --------------- | ------- |
+| `custom-element-definition` | `my-element` | MyElement   | ./my-element.js |         |

--- a/packages/to-markdown/fixtures/hide-private/README.md
+++ b/packages/to-markdown/fixtures/hide-private/README.md
@@ -4,22 +4,22 @@
 
 ### Fields
 
-| Name | Privacy   | Type          | Default       | Description | Inherited From |
-| ---- | --------- | ------------- | ------------- | ----------- | -------------- |
-| pub  | public    | `'public'`    | `'public'`    |             |                |
-| prot | protected | `'protected'` | `'protected'` |             |                |
+| Name   | Privacy   | Type          | Default       | Description | Inherited From |
+| ------ | --------- | ------------- | ------------- | ----------- | -------------- |
+| `pub`  | public    | `'public'`    | `'public'`    |             |                |
+| `prot` | protected | `'protected'` | `'protected'` |             |                |
 
 ### Methods
 
-| Name            | Privacy   | Description | Parameters | Return | Inherited From |
-| --------------- | --------- | ----------- | ---------- | ------ | -------------- |
-| publicMethod    | public    |             |            | `void` |                |
-| protectedMethod | protected |             |            | `void` |                |
+| Name              | Privacy   | Description | Parameters | Return | Inherited From |
+| ----------------- | --------- | ----------- | ---------- | ------ | -------------- |
+| `publicMethod`    | public    |             |            | `void` |                |
+| `protectedMethod` | protected |             |            | `void` |                |
 
 <hr/>
 
 ## Exports
 
-| Kind                      | Name       | Declaration | Module          | Package |
-| ------------------------- | ---------- | ----------- | --------------- | ------- |
-| custom-element-definition | my-element | MyElement   | ./my-element.js |         |
+| Kind                        | Name         | Declaration | Module          | Package |
+| --------------------------- | ------------ | ----------- | --------------- | ------- |
+| `custom-element-definition` | `my-element` | MyElement   | ./my-element.js |         |

--- a/packages/to-markdown/fixtures/kitchen-sink/EXPECTED.md
+++ b/packages/to-markdown/fixtures/kitchen-sink/EXPECTED.md
@@ -4,21 +4,21 @@
 
 ### Superclass
 
-| Name       | Module | Package     |
-| ---------- | ------ | ----------- |
-| LitElement |        | lit-element |
+| Name         | Module | Package     |
+| ------------ | ------ | ----------- |
+| `LitElement` |        | lit-element |
 
 ### Methods
 
-| Name             | Privacy | Description | Parameters | Return | Inherited From |
-| ---------------- | ------- | ----------- | ---------- | ------ | -------------- |
-| superClassMethod | public  |             |            |        |                |
+| Name               | Privacy | Description | Parameters | Return | Inherited From |
+| ------------------ | ------- | ----------- | ---------- | ------ | -------------- |
+| `superClassMethod` | public  |             |            |        |                |
 
 ### Events
 
-| Name         | Type               | Description    | Inherited From |
-| ------------ | ------------------ | -------------- | -------------- |
-| custom-event | `SuperCustomEvent` | this is custom |                |
+| Name           | Type               | Description    | Inherited From |
+| -------------- | ------------------ | -------------- | -------------- |
+| `custom-event` | `SuperCustomEvent` | this is custom |                |
 
 <hr/>
 
@@ -26,65 +26,77 @@
 
 ### Superclass
 
-| Name       | Module                                 | Package |
-| ---------- | -------------------------------------- | ------- |
-| SuperClass | ./fixtures/-TEST/package/my-element.js |         |
+| Name         | Module                                 | Package |
+| ------------ | -------------------------------------- | ------- |
+| `SuperClass` | ./fixtures/-TEST/package/my-element.js |         |
 
 ### Mixins
 
-| Name          | Module                                 | Package |
-| ------------- | -------------------------------------- | ------- |
-| LocalizeMixin |                                        | lion    |
-| Mixin         | ./fixtures/-TEST/package/my-element.js |         |
+| Name            | Module                                 | Package |
+| --------------- | -------------------------------------- | ------- |
+| `LocalizeMixin` |                                        | lion    |
+| `Mixin`         | ./fixtures/-TEST/package/my-element.js |         |
+
+### Static Fields
+
+| Name         | Privacy | Type     | Default | Description | Inherited From |
+| ------------ | ------- | -------- | ------- | ----------- | -------------- |
+| `properties` |         | `object` |         |             |                |
+
+### Static Methods
+
+| Name           | Privacy | Description | Parameters | Return | Inherited From |
+| -------------- | ------- | ----------- | ---------- | ------ | -------------- |
+| `staticMethod` |         |             |            |        |                |
 
 ### Fields
 
-| Name      | Privacy   | Type      | Default | Description           | Inherited From |
-| --------- | --------- | --------- | ------- | --------------------- | -------------- |
-| prop1     | public    |           |         |                       |                |
-| prop2     | public    |           |         |                       |                |
-| prop3     | public    | `boolean` | `true`  |                       |                |
-| foo       | private   | `string`  | `'bar'` | description goes here |                |
-| mixinProp | protected | `number`  | `1`     |                       | Mixin          |
+| Name        | Privacy   | Type      | Default | Description           | Inherited From |
+| ----------- | --------- | --------- | ------- | --------------------- | -------------- |
+| `prop1`     | public    |           |         |                       |                |
+| `prop2`     | public    |           |         |                       |                |
+| `prop3`     | public    | `boolean` | `true`  |                       |                |
+| `foo`       | private   | `string`  | `'bar'` | description goes here |                |
+| `mixinProp` | protected | `number`  | `1`     |                       | Mixin          |
 
 ### Methods
 
-| Name             | Privacy | Description                         | Parameters            | Return | Inherited From |
-| ---------------- | ------- | ----------------------------------- | --------------------- | ------ | -------------- |
-| instanceMethod   | public  | Some description of the method here | `e: Event, a: string` |        |                |
-| superClassMethod | public  |                                     |                       |        | SuperClass     |
+| Name               | Privacy | Description                         | Parameters            | Return | Inherited From |
+| ------------------ | ------- | ----------------------------------- | --------------------- | ------ | -------------- |
+| `instanceMethod`   | public  | Some description of the method here | `e: Event, a: string` |        |                |
+| `superClassMethod` | public  |                                     |                       |        | SuperClass     |
 
 ### Events
 
-| Name         | Type               | Description    | Inherited From |
-| ------------ | ------------------ | -------------- | -------------- |
-| my-event     | `Event`            |                |                |
-| custom-event | `SuperCustomEvent` | this is custom | SuperClass     |
+| Name           | Type               | Description    | Inherited From |
+| -------------- | ------------------ | -------------- | -------------- |
+| `my-event`     | `Event`            |                |                |
+| `custom-event` | `SuperCustomEvent` | this is custom | SuperClass     |
 
 ### Attributes
 
-| Name   | Field | Inherited From |
-| ------ | ----- | -------------- |
-| prop-1 | prop1 |                |
-| prop2  | prop2 |                |
+| Name     | Field | Inherited From |
+| -------- | ----- | -------------- |
+| `prop-1` | prop1 |                |
+| `prop2`  | prop2 |                |
 
 ### CSS Properties
 
-| Name               | Default         | Description               |
-| ------------------ | --------------- | ------------------------- |
-| --background-color | `rebeccapurple` | Controls the color of bar |
+| Name                 | Default         | Description               |
+| -------------------- | --------------- | ------------------------- |
+| `--background-color` | `rebeccapurple` | Controls the color of bar |
 
 ### CSS Parts
 
-| Name | Description             |
-| ---- | ----------------------- |
-| bar  | Styles the color of bar |
+| Name  | Description             |
+| ----- | ----------------------- |
+| `bar` | Styles the color of bar |
 
 ### Slots
 
-| Name      | Description                    |
-| --------- | ------------------------------ |
-| container | You can put some elements here |
+| Name        | Description                    |
+| ----------- | ------------------------------ |
+| `container` | You can put some elements here |
 
 <hr/>
 
@@ -92,10 +104,10 @@
 
 ### Parameters
 
-| Name  | Type     | Default | Description             |
-| ----- | -------- | ------- | ----------------------- |
-| klass | `*`      |         | This is the description |
-| foo   | `string` |         | Description goes here   |
+| Name    | Type     | Default | Description             |
+| ------- | -------- | ------- | ----------------------- |
+| `klass` | `*`      |         | This is the description |
+| `foo`   | `string` |         | Description goes here   |
 
 <hr/>
 
@@ -103,41 +115,41 @@
 
 ### Parameters
 
-| Name  | Type | Default | Description             |
-| ----- | ---- | ------- | ----------------------- |
-| klass | `*`  |         | This is the description |
+| Name    | Type | Default | Description             |
+| ------- | ---- | ------- | ----------------------- |
+| `klass` | `*`  |         | This is the description |
 
 ### Fields
 
-| Name      | Privacy   | Type     | Default | Description | Inherited From |
-| --------- | --------- | -------- | ------- | ----------- | -------------- |
-| mixinProp | protected | `number` | `1`     |             |                |
+| Name        | Privacy   | Type     | Default | Description | Inherited From |
+| ----------- | --------- | -------- | ------- | ----------- | -------------- |
+| `mixinProp` | protected | `number` | `1`     |             |                |
 
 <hr/>
 
 ## Variables
 
-| Name                 | Description                 | Type      |
-| -------------------- | --------------------------- | --------- |
-| variableExport       | this is a var export        | `boolean` |
-| stringVariableExport | this is a string var export | `string`  |
+| Name                   | Description                 | Type      |
+| ---------------------- | --------------------------- | --------- |
+| `variableExport`       | this is a var export        | `boolean` |
+| `stringVariableExport` | this is a string var export | `string`  |
 
 <hr/>
 
 ## Functions
 
-| Name           | Description               | Parameters              | Return    |
-| -------------- | ------------------------- | ----------------------- | --------- |
-| functionExport | This is a function export | `a: string, b: boolean` | `boolean` |
+| Name             | Description               | Parameters              | Return    |
+| ---------------- | ------------------------- | ----------------------- | --------- |
+| `functionExport` | This is a function export | `a: string, b: boolean` | `boolean` |
 
 <hr/>
 
 ## Exports
 
-| Kind                      | Name                 | Declaration          | Module                                 | Package |
-| ------------------------- | -------------------- | -------------------- | -------------------------------------- | ------- |
-| js                        | SuperClass           | SuperClass           | ./fixtures/-TEST/package/my-element.js |         |
-| custom-element-definition | my-element           | MyElement            | ./fixtures/-TEST/package/my-element.js |         |
-| js                        | variableExport       | variableExport       | ./fixtures/-TEST/package/my-element.js |         |
-| js                        | stringVariableExport | stringVariableExport | ./fixtures/-TEST/package/my-element.js |         |
-| js                        | functionExport       | functionExport       | ./fixtures/-TEST/package/my-element.js |         |
+| Kind                        | Name                   | Declaration          | Module                                 | Package |
+| --------------------------- | ---------------------- | -------------------- | -------------------------------------- | ------- |
+| `js`                        | `SuperClass`           | SuperClass           | ./fixtures/-TEST/package/my-element.js |         |
+| `custom-element-definition` | `my-element`           | MyElement            | ./fixtures/-TEST/package/my-element.js |         |
+| `js`                        | `variableExport`       | variableExport       | ./fixtures/-TEST/package/my-element.js |         |
+| `js`                        | `stringVariableExport` | stringVariableExport | ./fixtures/-TEST/package/my-element.js |         |
+| `js`                        | `functionExport`       | functionExport       | ./fixtures/-TEST/package/my-element.js |         |

--- a/packages/to-markdown/fixtures/kitchen-sink/README.md
+++ b/packages/to-markdown/fixtures/kitchen-sink/README.md
@@ -4,21 +4,21 @@
 
 ### Superclass
 
-| Name       | Module | Package     |
-| ---------- | ------ | ----------- |
-| LitElement |        | lit-element |
+| Name         | Module | Package     |
+| ------------ | ------ | ----------- |
+| `LitElement` |        | lit-element |
 
 ### Methods
 
-| Name             | Privacy | Description | Parameters | Return | Inherited From |
-| ---------------- | ------- | ----------- | ---------- | ------ | -------------- |
-| superClassMethod | public  |             |            |        |                |
+| Name               | Privacy | Description | Parameters | Return | Inherited From |
+| ------------------ | ------- | ----------- | ---------- | ------ | -------------- |
+| `superClassMethod` | public  |             |            |        |                |
 
 ### Events
 
-| Name         | Type               | Description    | Inherited From |
-| ------------ | ------------------ | -------------- | -------------- |
-| custom-event | `SuperCustomEvent` | this is custom |                |
+| Name           | Type               | Description    | Inherited From |
+| -------------- | ------------------ | -------------- | -------------- |
+| `custom-event` | `SuperCustomEvent` | this is custom |                |
 
 <hr/>
 
@@ -26,65 +26,77 @@
 
 ### Superclass
 
-| Name       | Module                                 | Package |
-| ---------- | -------------------------------------- | ------- |
-| SuperClass | ./fixtures/-TEST/package/my-element.js |         |
+| Name         | Module                                 | Package |
+| ------------ | -------------------------------------- | ------- |
+| `SuperClass` | ./fixtures/-TEST/package/my-element.js |         |
 
 ### Mixins
 
-| Name          | Module                                 | Package |
-| ------------- | -------------------------------------- | ------- |
-| LocalizeMixin |                                        | lion    |
-| Mixin         | ./fixtures/-TEST/package/my-element.js |         |
+| Name            | Module                                 | Package |
+| --------------- | -------------------------------------- | ------- |
+| `LocalizeMixin` |                                        | lion    |
+| `Mixin`         | ./fixtures/-TEST/package/my-element.js |         |
+
+### Static Fields
+
+| Name         | Privacy | Type     | Default | Description | Inherited From |
+| ------------ | ------- | -------- | ------- | ----------- | -------------- |
+| `properties` |         | `object` |         |             |                |
+
+### Static Methods
+
+| Name           | Privacy | Description | Parameters | Return | Inherited From |
+| -------------- | ------- | ----------- | ---------- | ------ | -------------- |
+| `staticMethod` |         |             |            |        |                |
 
 ### Fields
 
-| Name      | Privacy   | Type      | Default | Description           | Inherited From |
-| --------- | --------- | --------- | ------- | --------------------- | -------------- |
-| prop1     | public    |           |         |                       |                |
-| prop2     | public    |           |         |                       |                |
-| prop3     | public    | `boolean` | `true`  |                       |                |
-| foo       | private   | `string`  | `'bar'` | description goes here |                |
-| mixinProp | protected | `number`  | `1`     |                       | Mixin          |
+| Name        | Privacy   | Type      | Default | Description           | Inherited From |
+| ----------- | --------- | --------- | ------- | --------------------- | -------------- |
+| `prop1`     | public    |           |         |                       |                |
+| `prop2`     | public    |           |         |                       |                |
+| `prop3`     | public    | `boolean` | `true`  |                       |                |
+| `foo`       | private   | `string`  | `'bar'` | description goes here |                |
+| `mixinProp` | protected | `number`  | `1`     |                       | Mixin          |
 
 ### Methods
 
-| Name             | Privacy | Description                         | Parameters            | Return | Inherited From |
-| ---------------- | ------- | ----------------------------------- | --------------------- | ------ | -------------- |
-| instanceMethod   | public  | Some description of the method here | `e: Event, a: string` |        |                |
-| superClassMethod | public  |                                     |                       |        | SuperClass     |
+| Name               | Privacy | Description                         | Parameters            | Return | Inherited From |
+| ------------------ | ------- | ----------------------------------- | --------------------- | ------ | -------------- |
+| `instanceMethod`   | public  | Some description of the method here | `e: Event, a: string` |        |                |
+| `superClassMethod` | public  |                                     |                       |        | SuperClass     |
 
 ### Events
 
-| Name         | Type               | Description    | Inherited From |
-| ------------ | ------------------ | -------------- | -------------- |
-| my-event     | `Event`            |                |                |
-| custom-event | `SuperCustomEvent` | this is custom | SuperClass     |
+| Name           | Type               | Description    | Inherited From |
+| -------------- | ------------------ | -------------- | -------------- |
+| `my-event`     | `Event`            |                |                |
+| `custom-event` | `SuperCustomEvent` | this is custom | SuperClass     |
 
 ### Attributes
 
-| Name   | Field | Inherited From |
-| ------ | ----- | -------------- |
-| prop-1 | prop1 |                |
-| prop2  | prop2 |                |
+| Name     | Field | Inherited From |
+| -------- | ----- | -------------- |
+| `prop-1` | prop1 |                |
+| `prop2`  | prop2 |                |
 
 ### CSS Properties
 
-| Name               | Default         | Description               |
-| ------------------ | --------------- | ------------------------- |
-| --background-color | `rebeccapurple` | Controls the color of bar |
+| Name                 | Default         | Description               |
+| -------------------- | --------------- | ------------------------- |
+| `--background-color` | `rebeccapurple` | Controls the color of bar |
 
 ### CSS Parts
 
-| Name | Description             |
-| ---- | ----------------------- |
-| bar  | Styles the color of bar |
+| Name  | Description             |
+| ----- | ----------------------- |
+| `bar` | Styles the color of bar |
 
 ### Slots
 
-| Name      | Description                    |
-| --------- | ------------------------------ |
-| container | You can put some elements here |
+| Name        | Description                    |
+| ----------- | ------------------------------ |
+| `container` | You can put some elements here |
 
 <hr/>
 
@@ -92,10 +104,10 @@
 
 ### Parameters
 
-| Name  | Type     | Default | Description             |
-| ----- | -------- | ------- | ----------------------- |
-| klass | `*`      |         | This is the description |
-| foo   | `string` |         | Description goes here   |
+| Name    | Type     | Default | Description             |
+| ------- | -------- | ------- | ----------------------- |
+| `klass` | `*`      |         | This is the description |
+| `foo`   | `string` |         | Description goes here   |
 
 <hr/>
 
@@ -103,41 +115,41 @@
 
 ### Parameters
 
-| Name  | Type | Default | Description             |
-| ----- | ---- | ------- | ----------------------- |
-| klass | `*`  |         | This is the description |
+| Name    | Type | Default | Description             |
+| ------- | ---- | ------- | ----------------------- |
+| `klass` | `*`  |         | This is the description |
 
 ### Fields
 
-| Name      | Privacy   | Type     | Default | Description | Inherited From |
-| --------- | --------- | -------- | ------- | ----------- | -------------- |
-| mixinProp | protected | `number` | `1`     |             |                |
+| Name        | Privacy   | Type     | Default | Description | Inherited From |
+| ----------- | --------- | -------- | ------- | ----------- | -------------- |
+| `mixinProp` | protected | `number` | `1`     |             |                |
 
 <hr/>
 
 ## Variables
 
-| Name                 | Description                 | Type      |
-| -------------------- | --------------------------- | --------- |
-| variableExport       | this is a var export        | `boolean` |
-| stringVariableExport | this is a string var export | `string`  |
+| Name                   | Description                 | Type      |
+| ---------------------- | --------------------------- | --------- |
+| `variableExport`       | this is a var export        | `boolean` |
+| `stringVariableExport` | this is a string var export | `string`  |
 
 <hr/>
 
 ## Functions
 
-| Name           | Description               | Parameters              | Return    |
-| -------------- | ------------------------- | ----------------------- | --------- |
-| functionExport | This is a function export | `a: string, b: boolean` | `boolean` |
+| Name             | Description               | Parameters              | Return    |
+| ---------------- | ------------------------- | ----------------------- | --------- |
+| `functionExport` | This is a function export | `a: string, b: boolean` | `boolean` |
 
 <hr/>
 
 ## Exports
 
-| Kind                      | Name                 | Declaration          | Module                                 | Package |
-| ------------------------- | -------------------- | -------------------- | -------------------------------------- | ------- |
-| js                        | SuperClass           | SuperClass           | ./fixtures/-TEST/package/my-element.js |         |
-| custom-element-definition | my-element           | MyElement            | ./fixtures/-TEST/package/my-element.js |         |
-| js                        | variableExport       | variableExport       | ./fixtures/-TEST/package/my-element.js |         |
-| js                        | stringVariableExport | stringVariableExport | ./fixtures/-TEST/package/my-element.js |         |
-| js                        | functionExport       | functionExport       | ./fixtures/-TEST/package/my-element.js |         |
+| Kind                        | Name                   | Declaration          | Module                                 | Package |
+| --------------------------- | ---------------------- | -------------------- | -------------------------------------- | ------- |
+| `js`                        | `SuperClass`           | SuperClass           | ./fixtures/-TEST/package/my-element.js |         |
+| `custom-element-definition` | `my-element`           | MyElement            | ./fixtures/-TEST/package/my-element.js |         |
+| `js`                        | `variableExport`       | variableExport       | ./fixtures/-TEST/package/my-element.js |         |
+| `js`                        | `stringVariableExport` | stringVariableExport | ./fixtures/-TEST/package/my-element.js |         |
+| `js`                        | `functionExport`       | functionExport       | ./fixtures/-TEST/package/my-element.js |         |

--- a/packages/to-markdown/fixtures/kitchen-sink/custom-elements.json
+++ b/packages/to-markdown/fixtures/kitchen-sink/custom-elements.json
@@ -98,6 +98,19 @@
           "members": [
             {
               "kind": "field",
+              "name": "properties",
+              "type": {
+                "text": "object"
+              },
+              "static": true
+            },
+            {
+              "kind": "method",
+              "name": "staticMethod",
+              "static": true
+            },
+            {
+              "kind": "field",
               "name": "prop1",
               "privacy": "public"
             },

--- a/packages/to-markdown/fixtures/union-types/EXPECTED.md
+++ b/packages/to-markdown/fixtures/union-types/EXPECTED.md
@@ -2,23 +2,23 @@
 
 ## Variables
 
-| Name  | Description | Type            |
-| ----- | ----------- | --------------- |
-| union |             | `'a'\|'b'\|'c'` |
+| Name    | Description | Type            |
+| ------- | ----------- | --------------- |
+| `union` |             | `'a'\|'b'\|'c'` |
 
 <hr/>
 
 ## Functions
 
-| Name       | Description | Parameters               | Return    |
-| ---------- | ----------- | ------------------------ | --------- |
-| unionParam |             | `aOrBOrC: 'a'\|'b'\|'c'` | `boolean` |
+| Name         | Description | Parameters               | Return    |
+| ------------ | ----------- | ------------------------ | --------- |
+| `unionParam` |             | `aOrBOrC: 'a'\|'b'\|'c'` | `boolean` |
 
 <hr/>
 
 ## Exports
 
-| Kind | Name       | Declaration | Module                                 | Package |
-| ---- | ---------- | ----------- | -------------------------------------- | ------- |
-| js   | union      | union       | ./fixtures/-TEST/package/my-element.js |         |
-| js   | unionParam | unionParam  | ./fixtures/-TEST/package/my-element.js |         |
+| Kind | Name         | Declaration | Module                                 | Package |
+| ---- | ------------ | ----------- | -------------------------------------- | ------- |
+| `js` | `union`      | union       | ./fixtures/-TEST/package/my-element.js |         |
+| `js` | `unionParam` | unionParam  | ./fixtures/-TEST/package/my-element.js |         |

--- a/packages/to-markdown/fixtures/union-types/README.md
+++ b/packages/to-markdown/fixtures/union-types/README.md
@@ -2,23 +2,23 @@
 
 ## Variables
 
-| Name  | Description | Type            |
-| ----- | ----------- | --------------- |
-| union |             | `'a'\|'b'\|'c'` |
+| Name    | Description | Type            |
+| ------- | ----------- | --------------- |
+| `union` |             | `'a'\|'b'\|'c'` |
 
 <hr/>
 
 ## Functions
 
-| Name       | Description | Parameters               | Return    |
-| ---------- | ----------- | ------------------------ | --------- |
-| unionParam |             | `aOrBOrC: 'a'\|'b'\|'c'` | `boolean` |
+| Name         | Description | Parameters               | Return    |
+| ------------ | ----------- | ------------------------ | --------- |
+| `unionParam` |             | `aOrBOrC: 'a'\|'b'\|'c'` | `boolean` |
 
 <hr/>
 
 ## Exports
 
-| Kind | Name       | Declaration | Module                                 | Package |
-| ---- | ---------- | ----------- | -------------------------------------- | ------- |
-| js   | union      | union       | ./fixtures/-TEST/package/my-element.js |         |
-| js   | unionParam | unionParam  | ./fixtures/-TEST/package/my-element.js |         |
+| Kind | Name         | Declaration | Module                                 | Package |
+| ---- | ------------ | ----------- | -------------------------------------- | ------- |
+| `js` | `union`      | union       | ./fixtures/-TEST/package/my-element.js |         |
+| `js` | `unionParam` | unionParam  | ./fixtures/-TEST/package/my-element.js |         |

--- a/packages/to-markdown/index.js
+++ b/packages/to-markdown/index.js
@@ -2,27 +2,16 @@ import { html, heading, inlineCode, root, table, tableCell, tableRow, text } fro
 import {
   capital, repeat,
   compose, identity,
-  isPrivate, isProtected,
+  isPrivate, isProtected, isStatic,
   isLengthy,
   kindIs,
-  not, or,
+  and, not, or,
+  trace,
 } from './lib/fp.js';
+import * as CELLS from './lib/cells.js';
 import { serialize } from './lib/serialize.js';
 
 const line = html('<hr/>');
-
-const formatParameters = x =>
-  x?.parameters?.map(param => `${param?.name}${param?.type?.text ? `: ${param.type.text}` : ''}`).join(', ');
-
-const DECLARATION = { heading: 'Declaration',     get: x => x.declaration?.name ?? '' };
-const DEFAULT =     { heading: 'Default',         get: x => x.default, cellType: inlineCode };
-const ATTR_FIELD =  { heading: 'Field',           get: x => x.fieldName };
-const INHERITANCE = { heading: 'Inherited From',  get: x => x.inheritedFrom?.name ?? '' };
-const MODULE =      { heading: 'Module',          get: x => x.declaration?.module ?? '' };
-const PACKAGE =     { heading: 'Package',         get: x => x.declaration?.package ?? '' };
-const PARAMETERS =  { heading: 'Parameters',      get: formatParameters, cellType: inlineCode };
-const RETURN =      { heading: 'Return',          get: x => x.return?.type?.text ?? x.return, cellType: inlineCode };
-const TYPE =        { heading: 'Type',            get: x => x.type?.text ?? '', cellType: inlineCode };
 
 /** Options -> Declaration -> Heading */
 const declarationHeading = options =>
@@ -47,10 +36,11 @@ const defaultDescriptor = name =>
 const getDescriptor = x =>
   typeof x === 'string' ? defaultDescriptor(x) : x;
 
-/** [Declaration] -> Descriptor -> Column */
-const getColumn = (decls) =>
-  ({ heading, get, cellType = text }) =>
-    ({ heading, cellType, values: decls.map(x => get(x)) })
+/** Options -> [Declaration] -> Descriptor -> Column */
+const getColumnWithOptions = options =>
+  decls =>
+    ({ heading, get, cellType = text }) =>
+      ({ heading, cellType, values: decls.map(x => get(x, options)) })
 
 /** Column -> Cell */
 const getHeading = x =>
@@ -58,23 +48,28 @@ const getHeading = x =>
 
 /** Int -> Column -> Cell */
 const getCell = i =>
-  ({ values, cellType }) =>
-    tableCell(values[i] ? cellType(values[i]) : text(''))
+  ({ values, cellType = text }) => {
+    const value = values[i];
+    if (!value)
+      return tableCell(text(''));
+    if (cellType === 'raw')
+      return tableCell(value);
+    else
+      return tableCell(cellType(value ?? ''));
+  }
 
 /** [Column] -> (, Int) -> Row [Cell] */
 const getRows = columns =>
   (_, i) =>
     tableRow(columns.map(getCell(i)));
 
-/** Options -> String -> [String|Descriptor] -> [Declaration] -> Parent Table */
-const tableWithTitle = options =>
-  /**
-   * @template {import('custom-elements-manifest/schema').Declaration} T
-   * @param  {string} title
-   * @param  {(keyof T)|{ heading: string; get: (x: T[keyof T] => string)}[]} names
-   * @param  {T[]} decls
-   */
-  (title, names, _decls, { headingLevel = 3, filter } = { }) => {
+/**
+ * Options -> String -> [String|Descriptor] -> [Declaration] -> Parent Table
+ * @type {import("./types/main").CurriedTableFn}
+ */
+const tableWithTitle = options => {
+  const getColumn = getColumnWithOptions(options);
+  return (title, names, _decls, { headingLevel = 3, filter } = { }) => {
     const by = (
         typeof filter === 'function' ? filter
       : options?.private === 'hidden' ? not(isPrivate)
@@ -102,12 +97,9 @@ const tableWithTitle = options =>
       ),
     ];
   }
+}
 
-/**
- * @param  {import('custom-elements-manifest/schema').Module} mod
- * @param  {Options} options
- * @return {import('mdast').Parent}
- */
+/** @type {import("./types/main").MakeModuleDocFn} */
 function makeModuleDoc(mod, options) {
   const declarations = mod?.declarations ?? [];
   const exports = mod?.exports ?? [];
@@ -124,24 +116,27 @@ function makeModuleDoc(mod, options) {
     ...(declarations.flatMap(decl => {
 
       const { kind, members = [] } = decl;
-      const fields = members.filter(kindIs('field'));
-      const methods = members.filter(kindIs('method'));
+      const fields = members.filter(and(kindIs('field'), not(isStatic)));
+      const methods = members.filter(and(kindIs('method'), not(isStatic)));
+      const staticFields = members.filter(and(kindIs('field'), isStatic));
+      const staticMethods = members.filter(and(kindIs('method'), isStatic));
 
       const nodes = [
         !['mixin', 'class'].includes(kind) ? null : makeHeading(decl),
-        ...makeTable('Superclass', ['name', 'module', 'package'], [decl.superclass]),
-        ...makeTable('Mixins', ['name', 'module', 'package'], decl.mixins),
+        ...makeTable('Superclass', [CELLS.NAME, 'module', 'package'], [decl.superclass]),
+        ...makeTable('Mixins', [CELLS.NAME, 'module', 'package'], decl.mixins),
         ...kind === 'mixin' ?
-           makeTable('Parameters', ['name', TYPE, DEFAULT, 'description'], decl.parameters)
+           makeTable('Parameters', [CELLS.NAME, CELLS.TYPE, CELLS.DEFAULT, 'description'], decl.parameters)
          : [],
-        ...makeTable('Fields', ['name', 'privacy', TYPE, DEFAULT, 'description', INHERITANCE], fields),
-        ...makeTable('Methods', ['name', 'privacy', 'description', PARAMETERS, RETURN, INHERITANCE], methods),
-        ...makeTable('Events', ['name', TYPE, 'description', INHERITANCE], decl.events),
-        ...makeTable('Attributes', ['name', ATTR_FIELD, INHERITANCE], decl.attributes),
-        ...makeTable('CSS Properties', ['name', DEFAULT, 'description'], decl.cssProperties),
-        ...makeTable('CSS Parts', ['name', 'description'], decl.cssParts),
-        ...makeTable('Parts', ['name', 'description'], decl.parts),
-        ...makeTable('Slots', ['name', 'description'], decl.slots),
+        ...makeTable('Static Fields', [CELLS.NAME, 'privacy', CELLS.TYPE, CELLS.DEFAULT, 'description', CELLS.INHERITANCE], staticFields),
+        ...makeTable('Static Methods', [CELLS.NAME, 'privacy', 'description', CELLS.PARAMETERS, CELLS.RETURN, CELLS.INHERITANCE], staticMethods),
+        ...makeTable('Fields', [CELLS.NAME, 'privacy', CELLS.TYPE, CELLS.DEFAULT, 'description', CELLS.INHERITANCE], fields),
+        ...makeTable('Methods', [CELLS.NAME, 'privacy', 'description', CELLS.PARAMETERS, CELLS.RETURN, CELLS.INHERITANCE], methods),
+        ...makeTable('Events', [CELLS.NAME, CELLS.TYPE, 'description', CELLS.INHERITANCE], decl.events),
+        ...makeTable('Attributes', [CELLS.NAME, CELLS.ATTR_FIELD, CELLS.INHERITANCE], decl.attributes),
+        ...makeTable('CSS Properties', [CELLS.NAME, CELLS.DEFAULT, 'description'], decl.cssProperties),
+        ...makeTable('CSS Parts', [CELLS.NAME, 'description'], decl.cssParts),
+        ...makeTable('Slots', [CELLS.NAME, 'description'], decl.slots),
       ].filter(identity);
 
       if (
@@ -151,8 +146,8 @@ function makeModuleDoc(mod, options) {
       ) {
         nodes.push(
           html('<details><summary>Private API</summary>'),
-          ...makeTable('Fields', ['name', 'privacy', TYPE, DEFAULT, 'description', INHERITANCE], fields.filter(or(isPrivate, isProtected)), { filter: identity }),
-          ...makeTable('Methods', ['name', 'privacy', 'description', PARAMETERS, RETURN, INHERITANCE], methods.filter(or(isPrivate, isProtected)), { filter: identity }),
+          ...makeTable('Fields', [CELLS.NAME, 'privacy', CELLS.TYPE, CELLS.DEFAULT, 'description', CELLS.INHERITANCE], fields.filter(or(isPrivate, isProtected)), { filter: identity }),
+          ...makeTable('Methods', [CELLS.NAME, 'privacy', 'description', CELLS.PARAMETERS, CELLS.RETURN, CELLS.INHERITANCE], methods.filter(or(isPrivate, isProtected)), { filter: identity }),
           html('</details>')
         );
       }
@@ -163,19 +158,18 @@ function makeModuleDoc(mod, options) {
       return nodes;
     })),
 
-    ...makeTable('Variables', ['name', 'description', TYPE], variables, { headingLevel: 2} ),
+    ...makeTable('Variables', [CELLS.NAME, 'description', CELLS.TYPE], variables, { headingLevel: 2} ),
     ...variables.length ? [line] : [],
-    ...makeTable('Functions', ['name', 'description', PARAMETERS, RETURN], functions, { headingLevel: 2} ),
+    ...makeTable('Functions', [CELLS.NAME, 'description', CELLS.PARAMETERS, CELLS.RETURN], functions, { headingLevel: 2} ),
     ...functions.length ? [line] : [],
-    ...makeTable('Exports', ['kind', 'name', DECLARATION, MODULE, PACKAGE], mod.exports, { headingLevel: 2} ),
+    ...makeTable('Exports', [CELLS.EXPORT_KIND, CELLS.NAME, CELLS.DECLARATION, CELLS.MODULE, CELLS.PACKAGE], mod.exports, { headingLevel: 2} ),
   ].filter(identity)
-
-
 }
 
 /**
  * Renders a custom elements manifest as Markdown
  * @param  {import('custom-elements-manifest/schema').Package} manifest
+ * @param  {import('./types/main').Options} manifest
  * @return {string}
  */
 export function customElementsManifestToMarkdown(manifest, options) {

--- a/packages/to-markdown/lib/cells.js
+++ b/packages/to-markdown/lib/cells.js
@@ -1,0 +1,29 @@
+import { inlineCode, image, text } from 'mdast-builder';
+
+const formatParam = param =>
+  `${param?.name}${param?.type?.text ? `: ${param.type.text}` : ''}`;
+
+const formatParameters = x =>
+  x?.parameters?.map(formatParam).join(', ');
+
+function getExportKind(x, options) {
+  const configured = options?.exportKinds?.[x.kind];
+  if (configured?.url)
+    return image(configured.url, null, x.kind);
+  else if (typeof configured === 'string')
+    return text(configured);
+  else
+    return x.kind ? inlineCode(x.kind) : text('');
+}
+
+export const DECLARATION = { heading: 'Declaration',     get: x => x.declaration?.name ?? '' };
+export const DEFAULT     = { heading: 'Default',         get: x => x.default, cellType: inlineCode };
+export const NAME        = { heading: 'Name',            get: x => x.name, cellType: inlineCode };
+export const ATTR_FIELD  = { heading: 'Field',           get: x => x.fieldName };
+export const INHERITANCE = { heading: 'Inherited From',  get: x => x.inheritedFrom?.name ?? '' };
+export const MODULE      = { heading: 'Module',          get: x => x.declaration?.module ?? '' };
+export const PACKAGE     = { heading: 'Package',         get: x => x.declaration?.package ?? '' };
+export const PARAMETERS  = { heading: 'Parameters',      get: formatParameters, cellType: inlineCode };
+export const RETURN      = { heading: 'Return',          get: x => x.return?.type?.text ?? x.return, cellType: inlineCode };
+export const TYPE        = { heading: 'Type',            get: x => x.type?.text ?? '', cellType: inlineCode };
+export const EXPORT_KIND = { heading: 'Kind',            get: getExportKind, cellType: 'raw' };

--- a/packages/to-markdown/lib/fp.js
+++ b/packages/to-markdown/lib/fp.js
@@ -15,6 +15,7 @@ export const kind = x => x?.kind;
 
 // predicates
 export const isSame = test => x => x === test;
+export const isStatic = x => x?.static ?? false;
 export const isPrivate = compose(isSame('private'), privacy);
 export const isProtected = compose(isSame('protected'), privacy);
 export const isClass = compose(isSame('class'), privacy);

--- a/packages/to-markdown/package.json
+++ b/packages/to-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@custom-elements-manifest/to-markdown",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "",
   "license": "MIT",
   "repository": {
@@ -10,6 +10,7 @@
   },
   "author": "open-wc",
   "homepage": "https://github.com/open-wc/custom-elements-manifest",
+  "types": "types/main.d.ts",
   "bugs": {
     "url": "https://github.com/open-wc/custom-elements-manifest"
   },

--- a/packages/to-markdown/test/to-markdown.test.js
+++ b/packages/to-markdown/test/to-markdown.test.js
@@ -10,6 +10,18 @@ import { normalize } from '../lib/serialize.js';
 const fixturesDir = path.join(process.cwd(), 'fixtures');
 let testCases = fs.readdirSync(fixturesDir);
 
+const OPTIONS = {
+    'heading-offset-2': { headingOffset: 2 },
+    'hide-private': { private: 'hidden' },
+    'details-private': { private: 'details' },
+    'export-kinds': {
+      exportKinds: {
+        'js': 'JavaScript',
+        'custom-element-definition': { url: 'https://raw.githubusercontent.com/webcomponents/webcomponents.org/master/client/assets/logo.svg' }
+      }
+    }
+};
+
 testCases.forEach(testCase => {
   test(`Testcase ${testCase}`, async () => {
     const manifestPath = path.join(fixturesDir, `${testCase}/custom-elements.json`);
@@ -17,15 +29,7 @@ testCases.forEach(testCase => {
     const outputPath = path.join(fixturesDir, `${testCase}/README.md`);
     const expectPath = path.join(fixturesDir, `${testCase}/EXPECTED.md`);
 
-    let options;
-    switch (testCase) {
-      case 'heading-offset-2':
-        options = { headingOffset: 2 }; break;
-      case 'hide-private':
-        options = { private: 'hidden' }; break;
-      case 'details-private':
-        options = { private: 'details' }; break;
-    }
+    const { description, ...options } = OPTIONS[testCase] ?? {}
 
     const output = customElementsManifestToMarkdown(manifest, options);
 
@@ -33,10 +37,7 @@ testCases.forEach(testCase => {
 
     fs.writeFileSync(outputPath, output, 'utf8');
 
-    assert.equal(
-      normalize(output),
-      normalize(expected)
-    );
+    assert.equal(normalize(output), normalize(expected), description);
   });
 });
 

--- a/packages/to-markdown/types/main.d.ts
+++ b/packages/to-markdown/types/main.d.ts
@@ -1,0 +1,37 @@
+import { Declaration, Module } from 'custom-elements-manifest/schema';
+import { Node, Parent } from 'mdast';
+
+export interface Options {
+  private?: 'details'|'hidden'|'all';
+  headingOffset?: number;
+}
+
+export interface Descriptor {
+  heading: string;
+  get: (x: T[keyof T]) => string;
+  cellType?: (value: string) => Node;
+  exportKinds?: {
+    'js'?: string;
+    'custom-element-definition'?: string;
+  }
+};
+
+export type CurriedTableFn =
+  (options: Options) =>
+    <T extends Declaration>(
+      title: string,
+      names: (keyof T)|Descriptor[],
+      decls: T[],
+      options?: {
+        headingLevel: number;
+        filter: (...args: any[]) => boolean;
+      },
+    ) => Node[];
+
+export type MakeModuleDocFn =
+  (mod: Module, options: Options) => Parent;
+
+/**
+ * Renders a custom elements manifest as Markdown
+ */
+export declare function customElementsManifestToMarkdown(manifest: Package, options: Options): string;

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -4,13 +4,13 @@ Generates a `README.md` file for a custom element package
 
 ## Options
 
-| Option        | Type    | Description | Default |
-| ------------- | ------- | ------------------------------------------------------ | ----------------------- |
-| from          | string  | absolute path to package root                          | 2 dirs above the plugin |
-| to            | string  | relative path from package root                        | `'README.md'`           |
-| headingOffset | integer | number of levels to offset generated markdown headings | `1`                     |
-| header        | string  | relative path to header file                           | `undefined`             |
-| footer        | string  | relative path to footer file                           | `undefined`             |
+| Option        | Type    | Description                                            | Default       |
+| ------------- | ------- | ------------------------------------------------------ | ------------- |
+| from          | string  | Path to package root (relative to current workign dir) | `.`           |
+| to            | string  | relative path from package root                        | `'README.md'` |
+| headingOffset | integer | number of levels to offset generated markdown headings | `1`           |
+| header        | string  | relative path to header file                           | `undefined`   |
+| footer        | string  | relative path to footer file                           | `undefined`   |
 
 ## Example
 

--- a/plugins/readme/index.js
+++ b/plugins/readme/index.js
@@ -1,12 +1,10 @@
 import { customElementsManifestToMarkdown } from '@custom-elements-manifest/to-markdown';
-
 import { mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { dirname, isAbsolute, join, resolve } from 'path';
 
 /**
  * @typedef {import('@custom-elements-manifest/to-markdown').Options} Options
- * @property {string} [from] absolute path to package root
+ * @property {string} [from] path to package root, relative to current working directory
  * @property {string} [to="README.md"] relative path from package root to output file
  * @property {number} [headingOffset=1] offset for markdown heading level
  * @property {string} [header] relative path to header file
@@ -21,7 +19,7 @@ export function readmePlugin(options) {
   const {
     header,
     footer,
-    from = join(dirname(fileURLToPath(import.meta.url)), '..', '..'),
+    from = '.',
     to = 'README.md',
     headingOffset = 1,
     exportKinds,
@@ -29,7 +27,9 @@ export function readmePlugin(options) {
   return {
     name: 'readme',
     packageLinkPhase({ customElementsManifest }) {
-      const outPath = join(from, to);
+      const absPath = isAbsolute(from) ? from : resolve(process.cwd(), from);
+
+      const outPath = join(absPath, to);
 
       try {
         const head = header && readFileSync(join(from, header));

--- a/plugins/readme/index.js
+++ b/plugins/readme/index.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
 /**
- * @typedef {object} Options
+ * @typedef {import('@custom-elements-manifest/to-markdown').Options} Options
  * @property {string} [from] absolute path to package root
  * @property {string} [to="README.md"] relative path from package root to output file
  * @property {number} [headingOffset=1] offset for markdown heading level
@@ -19,11 +19,12 @@ import { dirname, join } from 'path';
  */
 export function readmePlugin(options) {
   const {
+    header,
+    footer,
     from = join(dirname(fileURLToPath(import.meta.url)), '..', '..'),
     to = 'README.md',
     headingOffset = 1,
-    header,
-    footer,
+    exportKinds,
   } = options ?? {};
   return {
     name: 'readme',
@@ -35,6 +36,7 @@ export function readmePlugin(options) {
         const foot = footer && readFileSync(join(from, footer));
 
         const markdown = customElementsManifestToMarkdown(customElementsManifest, {
+          exportKinds,
           headingOffset,
           private: options?.private ?? 'details',
         });

--- a/plugins/readme/package.json
+++ b/plugins/readme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cem-plugin-readme",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Generate README.md from custom elements sources",
   "author": "open-wc",
   "contributors": [
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "uvu test"
+    "test": "uvu test -i cases"
   },
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "readme"
   ],
   "dependencies": {
-    "@custom-elements-manifest/to-markdown": "^0.0.12"
+    "@custom-elements-manifest/to-markdown": "^0.0.13"
   },
   "peerDependencies": {
     "@custom-elements-manifest/analyzer": "^0.4.12"

--- a/plugins/readme/test/cases/custom-kinds/expected/README.md
+++ b/plugins/readme/test/cases/custom-kinds/expected/README.md
@@ -1,0 +1,43 @@
+## `fixture/my-element.js`:
+
+### class: `XL`, `x-l`
+
+#### Superclass
+
+| Name          | Module | Package |
+| ------------- | ------ | ------- |
+| `HTMLElement` |        |         |
+
+#### Fields
+
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet` |         | `string` | `'🥭'`  |             |                |
+
+<details><summary>Private API</summary>
+
+#### Fields
+
+| Name     | Privacy | Type     | Default | Description | Inherited From |
+| -------- | ------- | -------- | ------- | ----------- | -------------- |
+| `bitter` | private | `string` | `'🍎'`  |             |                |
+
+</details>
+
+<hr/>
+
+### Variables
+
+| Name | Description | Type     |
+| ---- | ----------- | -------- |
+| `js` |             | `string` |
+
+<hr/>
+
+### Exports
+
+| Kind                                                                                                                          | Name  | Declaration | Module                | Package |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----- | ----------- | --------------------- | ------- |
+| JavaScript                                                                                                                    | `XL`  | XL          | fixture/my-element.js |         |
+| ![custom-element-definition](https://raw.githubusercontent.com/webcomponents/webcomponents.org/master/client/assets/logo.svg) | `x-l` | XL          | fixture/my-element.js |         |
+| JavaScript                                                                                                                    | `js`  | js          | fixture/my-element.js |         |

--- a/plugins/readme/test/cases/custom-kinds/fixture/my-element.js
+++ b/plugins/readme/test/cases/custom-kinds/fixture/my-element.js
@@ -1,0 +1,9 @@
+export class XL extends HTMLElement {
+  sweet = '🥭';
+  /** @private */
+  bitter = '🍎';
+}
+
+customElements.define('x-l', XL);
+
+export var js = 'js';

--- a/plugins/readme/test/cases/custom-kinds/fixture/package.json
+++ b/plugins/readme/test/cases/custom-kinds/fixture/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test",
+  "type": "module"
+}

--- a/plugins/readme/test/cases/custom-kinds/out/README.md
+++ b/plugins/readme/test/cases/custom-kinds/out/README.md
@@ -1,0 +1,43 @@
+## `fixture/my-element.js`:
+
+### class: `XL`, `x-l`
+
+#### Superclass
+
+| Name          | Module | Package |
+| ------------- | ------ | ------- |
+| `HTMLElement` |        |         |
+
+#### Fields
+
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet` |         | `string` | `'🥭'`  |             |                |
+
+<details><summary>Private API</summary>
+
+#### Fields
+
+| Name     | Privacy | Type     | Default | Description | Inherited From |
+| -------- | ------- | -------- | ------- | ----------- | -------------- |
+| `bitter` | private | `string` | `'🍎'`  |             |                |
+
+</details>
+
+<hr/>
+
+### Variables
+
+| Name | Description | Type     |
+| ---- | ----------- | -------- |
+| `js` |             | `string` |
+
+<hr/>
+
+### Exports
+
+| Kind                                                                                                                          | Name  | Declaration | Module                | Package |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----- | ----------- | --------------------- | ------- |
+| JavaScript                                                                                                                    | `XL`  | XL          | fixture/my-element.js |         |
+| ![custom-element-definition](https://raw.githubusercontent.com/webcomponents/webcomponents.org/master/client/assets/logo.svg) | `x-l` | XL          | fixture/my-element.js |         |
+| JavaScript                                                                                                                    | `js`  | js          | fixture/my-element.js |         |

--- a/plugins/readme/test/cases/default-options/expected/README.md
+++ b/plugins/readme/test/cases/default-options/expected/README.md
@@ -4,17 +4,17 @@
 
 #### Fields
 
-| Name  | Privacy | Type     | Default | Description | Inherited From |
-| ----- | ------- | -------- | ------- | ----------- | -------------- |
-| sweet |         | `string` | `'🥭'`  |             |                |
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet` |         | `string` | `'🥭'`  |             |                |
 
 <details><summary>Private API</summary>
 
 #### Fields
 
-| Name   | Privacy | Type     | Default | Description | Inherited From |
-| ------ | ------- | -------- | ------- | ----------- | -------------- |
-| bitter | private | `string` | `'🍎'`  |             |                |
+| Name     | Privacy | Type     | Default | Description | Inherited From |
+| -------- | ------- | -------- | ------- | ----------- | -------------- |
+| `bitter` | private | `string` | `'🍎'`  |             |                |
 
 </details>
 
@@ -24,4 +24,4 @@
 
 | Kind | Name | Declaration | Module                | Package |
 | ---- | ---- | ----------- | --------------------- | ------- |
-| js   | XL   | XL          | fixture/my-element.js |         |
+| `js` | `XL` | XL          | fixture/my-element.js |         |

--- a/plugins/readme/test/cases/default-options/out/README.md
+++ b/plugins/readme/test/cases/default-options/out/README.md
@@ -4,17 +4,17 @@
 
 #### Fields
 
-| Name  | Privacy | Type     | Default | Description | Inherited From |
-| ----- | ------- | -------- | ------- | ----------- | -------------- |
-| sweet |         | `string` | `'🥭'`  |             |                |
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet` |         | `string` | `'🥭'`  |             |                |
 
 <details><summary>Private API</summary>
 
 #### Fields
 
-| Name   | Privacy | Type     | Default | Description | Inherited From |
-| ------ | ------- | -------- | ------- | ----------- | -------------- |
-| bitter | private | `string` | `'🍎'`  |             |                |
+| Name     | Privacy | Type     | Default | Description | Inherited From |
+| -------- | ------- | -------- | ------- | ----------- | -------------- |
+| `bitter` | private | `string` | `'🍎'`  |             |                |
 
 </details>
 
@@ -24,4 +24,4 @@
 
 | Kind | Name | Declaration | Module                | Package |
 | ---- | ---- | ----------- | --------------------- | ------- |
-| js   | XL   | XL          | fixture/my-element.js |         |
+| `js` | `XL` | XL          | fixture/my-element.js |         |

--- a/plugins/readme/test/cases/footer-only/expected/README.md
+++ b/plugins/readme/test/cases/footer-only/expected/README.md
@@ -4,9 +4,9 @@
 
 #### Fields
 
-| Name  | Privacy | Type     | Default | Description | Inherited From |
-| ----- | ------- | -------- | ------- | ----------- | -------------- |
-| sweet |         | `string` | `'🥭'`  |             |                |
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet` |         | `string` | `'🥭'`  |             |                |
 
 <hr/>
 
@@ -14,7 +14,7 @@
 
 | Kind | Name | Declaration | Module                | Package |
 | ---- | ---- | ----------- | --------------------- | ------- |
-| js   | XL   | XL          | fixture/my-element.js |         |
+| `js` | `XL` | XL          | fixture/my-element.js |         |
 
 
 Brought to you by the letter 'qu'

--- a/plugins/readme/test/cases/footer-only/out/README.md
+++ b/plugins/readme/test/cases/footer-only/out/README.md
@@ -4,9 +4,9 @@
 
 #### Fields
 
-| Name  | Privacy | Type     | Default | Description | Inherited From |
-| ----- | ------- | -------- | ------- | ----------- | -------------- |
-| sweet |         | `string` | `'🥭'`  |             |                |
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet` |         | `string` | `'🥭'`  |             |                |
 
 <hr/>
 
@@ -14,7 +14,7 @@
 
 | Kind | Name | Declaration | Module                | Package |
 | ---- | ---- | ----------- | --------------------- | ------- |
-| js   | XL   | XL          | fixture/my-element.js |         |
+| `js` | `XL` | XL          | fixture/my-element.js |         |
 
 
 Brought to you by the letter 'qu'

--- a/plugins/readme/test/cases/header-and-footer/expected/README.md
+++ b/plugins/readme/test/cases/header-and-footer/expected/README.md
@@ -9,17 +9,17 @@ A sweet lil' custom el.
 
 #### Fields
 
-| Name  | Privacy | Type     | Default | Description | Inherited From |
-| ----- | ------- | -------- | ------- | ----------- | -------------- |
-| sweet |         | `string` | `'🥭'`  |             |                |
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet` |         | `string` | `'🥭'`  |             |                |
 
 <details><summary>Private API</summary>
 
 #### Fields
 
-| Name   | Privacy | Type     | Default | Description | Inherited From |
-| ------ | ------- | -------- | ------- | ----------- | -------------- |
-| bitter | private | `string` | `'🍎'`  |             |                |
+| Name     | Privacy | Type     | Default | Description | Inherited From |
+| -------- | ------- | -------- | ------- | ----------- | -------------- |
+| `bitter` | private | `string` | `'🍎'`  |             |                |
 
 </details>
 
@@ -29,7 +29,7 @@ A sweet lil' custom el.
 
 | Kind | Name | Declaration | Module                | Package |
 | ---- | ---- | ----------- | --------------------- | ------- |
-| js   | XL   | XL          | fixture/my-element.js |         |
+| `js` | `XL` | XL          | fixture/my-element.js |         |
 
 
 Brought to you by the letter 'qu'

--- a/plugins/readme/test/cases/header-and-footer/out/README.md
+++ b/plugins/readme/test/cases/header-and-footer/out/README.md
@@ -9,17 +9,17 @@ A sweet lil' custom el.
 
 #### Fields
 
-| Name  | Privacy | Type     | Default | Description | Inherited From |
-| ----- | ------- | -------- | ------- | ----------- | -------------- |
-| sweet |         | `string` | `'🥭'`  |             |                |
+| Name    | Privacy | Type     | Default | Description | Inherited From |
+| ------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet` |         | `string` | `'🥭'`  |             |                |
 
 <details><summary>Private API</summary>
 
 #### Fields
 
-| Name   | Privacy | Type     | Default | Description | Inherited From |
-| ------ | ------- | -------- | ------- | ----------- | -------------- |
-| bitter | private | `string` | `'🍎'`  |             |                |
+| Name     | Privacy | Type     | Default | Description | Inherited From |
+| -------- | ------- | -------- | ------- | ----------- | -------------- |
+| `bitter` | private | `string` | `'🍎'`  |             |                |
 
 </details>
 
@@ -29,7 +29,7 @@ A sweet lil' custom el.
 
 | Kind | Name | Declaration | Module                | Package |
 | ---- | ---- | ----------- | --------------------- | ------- |
-| js   | XL   | XL          | fixture/my-element.js |         |
+| `js` | `XL` | XL          | fixture/my-element.js |         |
 
 
 Brought to you by the letter 'qu'

--- a/plugins/readme/test/cases/header-only/expected/README.md
+++ b/plugins/readme/test/cases/header-only/expected/README.md
@@ -9,10 +9,10 @@ A sweet lil' custom el.
 
 #### Fields
 
-| Name   | Privacy | Type     | Default | Description | Inherited From |
-| ------ | ------- | -------- | ------- | ----------- | -------------- |
-| sweet  |         | `string` | `'🥭'`  |             |                |
-| bitter | private | `string` | `'🍎'`  |             |                |
+| Name     | Privacy | Type     | Default | Description | Inherited From |
+| -------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet`  |         | `string` | `'🥭'`  |             |                |
+| `bitter` | private | `string` | `'🍎'`  |             |                |
 
 <hr/>
 
@@ -20,4 +20,4 @@ A sweet lil' custom el.
 
 | Kind | Name | Declaration | Module                | Package |
 | ---- | ---- | ----------- | --------------------- | ------- |
-| js   | XL   | XL          | fixture/my-element.js |         |
+| `js` | `XL` | XL          | fixture/my-element.js |         |

--- a/plugins/readme/test/cases/header-only/out/README.md
+++ b/plugins/readme/test/cases/header-only/out/README.md
@@ -9,10 +9,10 @@ A sweet lil' custom el.
 
 #### Fields
 
-| Name   | Privacy | Type     | Default | Description | Inherited From |
-| ------ | ------- | -------- | ------- | ----------- | -------------- |
-| sweet  |         | `string` | `'🥭'`  |             |                |
-| bitter | private | `string` | `'🍎'`  |             |                |
+| Name     | Privacy | Type     | Default | Description | Inherited From |
+| -------- | ------- | -------- | ------- | ----------- | -------------- |
+| `sweet`  |         | `string` | `'🥭'`  |             |                |
+| `bitter` | private | `string` | `'🍎'`  |             |                |
 
 <hr/>
 
@@ -20,4 +20,4 @@ A sweet lil' custom el.
 
 | Kind | Name | Declaration | Module                | Package |
 | ---- | ---- | ----------- | --------------------- | ------- |
-| js   | XL   | XL          | fixture/my-element.js |         |
+| `js` | `XL` | XL          | fixture/my-element.js |         |

--- a/plugins/readme/test/cem-plugin-readme.test.js
+++ b/plugins/readme/test/cem-plugin-readme.test.js
@@ -40,6 +40,13 @@ const OPTIONS = {
     description: 'Writes README using default options'
   },
 
+  'custom-kinds': {
+    description: 'Replaces export kinds with custom options',
+    exportKinds: {
+      'custom-element-definition': { url: 'https://raw.githubusercontent.com/webcomponents/webcomponents.org/master/client/assets/logo.svg' },
+      'js': 'JavaScript',
+    }
+  }
 };
 
 readdirSync(casesDir).forEach(testCase => {
@@ -55,7 +62,12 @@ readdirSync(casesDir).forEach(testCase => {
     const { description, ...options } = OPTIONS[testCase] ?? {};
 
     const customElementsManifest = create({
-      modules: [ts.createSourceFile(join('fixture', 'my-element.js'), source, ts.ScriptTarget.ES2015, true)],
+      modules: [ts.createSourceFile(
+        join('./fixture', 'my-element.js'),
+        source,
+        ts.ScriptTarget.ES2015,
+        true
+      )],
       plugins: [readmePlugin({ from, to, ...options })],
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,6 +298,13 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.0.tgz#3d6fb55803832766a24c6f339abc507297eb5d25"
   integrity sha512-VOR0NWFYX65n9gELQdcpqsie5L5ihBXuZGAgaPEp/U7IOSjnPMEH6geE+2f6lcekaNEfWzAHS45mPvSo5bqsUA==
 
+cem-plugin-readme@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cem-plugin-readme/-/cem-plugin-readme-0.1.2.tgz#65a4d6c8973bb9c42e2a68fb3053a353e5475379"
+  integrity sha512-K28QXc6nG22p+aHzdPnQQi3uM02HLkbERCqDCwLT11mmQMr+WS5sbXwnR4YYUhPc/kUbASUu+OoFLlgmQ+7RgQ==
+  dependencies:
+    "@custom-elements-manifest/to-markdown" "^0.0.9"
+
 chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"


### PR DESCRIPTION
What I Did

1. add `--readme` flag along with `--header`, `--footer`, and `--headingOffset` to analyzer.
  - adds `cem-plugin-readme` as a dep to analyzer
  - the code for readme is _lazy loaded_ only if the user provides the `--readme` flag, otherwise it's not imported

Alternative approaches considered:
- scan `node_modules` for cem plugins, kind of like how karma does it, and have those plugins export their own command line definitions
  - **PRO**: doesn't pollute analyzer with deps and extra code
  - **CON**: scanning `node_modules` is kind of gross? is there another way to do that?

Depends on #87