### PR TITLE
Fix: custom element define re-assign crashes analyzer

### DIFF
--- a/packages/analyzer/src/utils/ast-helpers.js
+++ b/packages/analyzer/src/utils/ast-helpers.js
@@ -18,7 +18,7 @@ export const isReturnStatement = statement => statement?.kind === ts.SyntaxKind.
  * @example customElements.define('my-el', MyEl);
  * @example window.customElements.define('my-el', MyEl);
  */
-export const isCustomElementsDefineCall = node => (node?.expression?.getText() === 'customElements' || node?.expression?.getText() === 'window.customElements') && node?.name?.getText() === 'define';
+export const isCustomElementsDefineCall = node => (node?.expression?.getText() === 'customElements' || node?.expression?.getText() === 'window.customElements') && node?.name?.getText() === 'define' && node?.parent?.kind === ts.SyntaxKind.CallExpression;
 
 /**
  * @example @attr


### PR DESCRIPTION
Some minifiers like to re-assign window functions, and while fiddling with the analyzer on minified files, I noticed that if the window.customElements.define -call gets re-defined, the analyzer breaks.

Playground: https://custom-elements-manifest.netlify.app/?source=dmFyIG49d2luZG93LmN1c3RvbUVsZW1lbnRzLmRlZmluZTsKCmNsYXNzIE15RWxlbWVudCBleHRlbmRzIEhUTUxFbGVtZW50IHsKICBzdGF0aWMgZ2V0IG9ic2VydmVkQXR0cmlidXRlcygpIHsKICAgIHJldHVybiBbJ2Rpc2FibGVkJ107CiAgfQoKICBzZXQgZGlzYWJsZWQodmFsKSB7CiAgICB0aGlzLl9fZGlzYWJsZWQgPSB2YWw7CiAgfQogIGdldCBkaXNhYmxlZCgpIHsKICAgIHJldHVybiB0aGlzLl9fZGlzYWJsZWQ7CiAgfQoKICBmaXJlKCkgewogICAgdGhpcy5kaXNwYXRjaEV2ZW50KG5ldyBFdmVudCgnZGlzYWJsZWQtY2hhbmdlZCcpKTsKICB9Cn0KCm4oJ215LWVsZW1lbnQnLCBNeUVsZW1lbnQpOwo%3D&library=null

---

To make sure it's actually a define CALL and not a re-assign, we need to check the parent's kind in the AST tree https://ts-ast-viewer.com/#code/G4QwTgBAdgvA7gSygEwPZwHQGMCuBnAF1QFsBRAGwFNjKoC8NlKAzJSgKHdElkRXWz4iZKjToMmrKJQAUASiA