### PR TITLE
Fix: PrefixUnaryExpression to check between boolean and number

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Release 0.4.16
+- Fixed resolving type from PrefixUnaryExpressions
+
+## Release 0.4.16
 - Added support for comma separated properties (handles minified code)
 
 ## Release 0.4.15

--- a/packages/analyzer/custom-elements.json
+++ b/packages/analyzer/custom-elements.json
@@ -34,6 +34,30 @@
                 "text": "number"
               },
               "default": "123"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop4",
+              "type": {
+                "text": "number"
+              },
+              "default": "+1"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop5",
+              "type": {
+                "text": "number"
+              },
+              "default": "-1"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop6",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "!1"
             }
           ],
           "superclass": {

--- a/packages/analyzer/fixtures/-default/package/bar.js
+++ b/packages/analyzer/fixtures/-default/package/bar.js
@@ -1,4 +1,8 @@
-export class GenericSwitch extends HTMLElement {
+export class GenericSwitch extends HTMLElement {  
+  prefixUnary1 = +1;
+  prefixUnary2 = -1;
+  prefixUnary3 = !1;
+
   constructor() {
     super();
     this.commaprop1 = 'default',

--- a/packages/analyzer/fixtures/class-fields/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/class-fields/fixture/custom-elements.json
@@ -227,6 +227,30 @@
             },
             {
               "kind": "field",
+              "name": "prefixUnary1",
+              "type": {
+                "text": "number"
+              },
+              "default": "+1"
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary2",
+              "type": {
+                "text": "number"
+              },
+              "default": "-1"
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary3",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "!1"
+            },
+            {
+              "kind": "field",
               "name": "commaprop1",
               "type": {
                 "text": "string"

--- a/packages/analyzer/fixtures/class-fields/package/my-element.js
+++ b/packages/analyzer/fixtures/class-fields/package/my-element.js
@@ -66,6 +66,10 @@ class MyEl extends HTMLElement {
 
   optional?: string;
 
+  prefixUnary1 = +1;
+  prefixUnary2 = -1;
+  prefixUnary3 = !1;
+
   constructor() {
     super();
     this.prop2 = 'default';

--- a/packages/analyzer/src/features/analyse-phase/creators/handlers.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/handlers.js
@@ -213,7 +213,8 @@ export function handleAttrJsDoc(node, doc) {
 }
 
 export function handleTypeInference(doc, node) {
-  switch(node?.initializer?.kind || node?.kind) {
+  const n = node?.initializer || node;
+  switch(n?.kind) {
     case ts.SyntaxKind.TrueKeyword:
     case ts.SyntaxKind.FalseKeyword:
       doc.type = { text: "boolean" }
@@ -221,8 +222,10 @@ export function handleTypeInference(doc, node) {
     case ts.SyntaxKind.StringLiteral:
       doc.type = { text: "string" }
       break;
-    case ts.SyntaxKind.NumericLiteral:
     case ts.SyntaxKind.PrefixUnaryExpression:
+      doc.type = n?.operator === ts.SyntaxKind.ExclamationToken ? { text: "boolean" } : { text: "number" };
+      break;
+    case ts.SyntaxKind.NumericLiteral:
       doc.type = { text: "number" }
       break;
     case ts.SyntaxKind.NullKeyword:


### PR DESCRIPTION
Bundlers sometimes optimize boolean values to from `true`to `!0` and `false` to `!1`. These are currently recognized as numbers, even though they are boolean values.

A small fix to handle this kind of state correctly.