### PR TITLE
Adds version from package.json to the default CLI message

### DIFF
--- a/packages/analyzer/index.js
+++ b/packages/analyzer/index.js
@@ -8,8 +8,6 @@ import commandLineArgs from 'command-line-args';
 import chokidar from 'chokidar';
 import debounce from 'debounce';
 
-const pkg = JSON.parse(`${fs.readFileSync(path.resolve('package.json'), 'utf-8')}`);
-
 import { create } from './src/create.js';
 import {
   getUserConfig,
@@ -111,6 +109,6 @@ import {
       console.log(`Could not add 'customElements' property to ${process.cwd()}${path.sep}package.json. \nAdding this property helps tooling locate your Custom Elements Manifest. Please consider adding it yourself, or file an issue if you think this is a bug.\nhttps://www.github.com/open-wc/custom-elements-manifest`);
     }
   } else {
-    console.log(MENU(pkg));
+    console.log(MENU);
   }
 })();

--- a/packages/analyzer/src/utils/cli.js
+++ b/packages/analyzer/src/utils/cli.js
@@ -5,10 +5,10 @@ import commandLineArgs from 'command-line-args';
 import { has } from './index.js';
 
 const IGNORE = [
-  '!node_modules/**/*.*', 
-  '!bower_components/**/*.*', 
-  '!**/*.test.{js,ts}', 
-  '!**/*.suite.{js,ts}', 
+  '!node_modules/**/*.*',
+  '!bower_components/**/*.*',
+  '!**/*.test.{js,ts}',
+  '!**/*.suite.{js,ts}',
   '!**/*.config.{js,ts}'
 ];
 
@@ -70,7 +70,7 @@ export function getCliConfig(argv) {
     { name: 'fast', type: Boolean },
     { name: 'catalyst', type: Boolean },
   ];
-  
+
   return commandLineArgs(optionDefinitions, { argv });
 }
 
@@ -120,8 +120,8 @@ export function addCustomElementsPropertyToPackageJson(outdir) {
   }
 }
 
-export const MENU = `
-@custom-elements-manifest/analyzer
+export const MENU = ({ version = ''}) => `
+@custom-elements-manifest/analyzer (${version})
 
 Available commands:
     | Command/option   | Type       | Description                                                 | Example                                                 |

--- a/packages/analyzer/src/utils/cli.js
+++ b/packages/analyzer/src/utils/cli.js
@@ -3,6 +3,10 @@ import fs from 'fs';
 import path from 'path';
 import commandLineArgs from 'command-line-args';
 import { has } from './index.js';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../../package.json');
 
 const IGNORE = [
   '!node_modules/**/*.*',
@@ -120,7 +124,7 @@ export function addCustomElementsPropertyToPackageJson(outdir) {
   }
 }
 
-export const MENU = ({ version = ''}) => `
+export const MENU = `
 @custom-elements-manifest/analyzer (${version})
 
 Available commands:

--- a/packages/find-dependencies/README.md
+++ b/packages/find-dependencies/README.md
@@ -111,4 +111,8 @@ getUniquePackages([
   'blank/node_modules/bar/index3.js'
 ]),
 // ['foo', 'bar',]
+
+/** Or */
+const dependencies = await findDependencies(inputPaths);
+const unique = getUniquePackages(dependencies);
 ```


### PR DESCRIPTION
It would be nice if the default CLI message would show the installed version of the analyser.

I have added parsing the version from the package's `package.json` file.