### PR TITLE
Do not output `type` property for CSS properties.

### DIFF
--- a/packages/analyzer/fixtures/class-jsdoc/package/my-element.js
+++ b/packages/analyzer/fixtures/class-jsdoc/package/my-element.js
@@ -21,7 +21,7 @@
  * @slot container - You can put some elements here
  *
  * @cssprop --text-color - Controls the color of foo
- * @cssproperty [--background-color=red] - Controls the color of bar
+ * @cssproperty {color} [--background-color=red] - Controls the color of bar
  *
  * @prop {boolean} prop1 - some description
  * @property {number} prop2 - some description

--- a/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
+++ b/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
@@ -74,6 +74,7 @@ export function classJsDocPlugin() {
                   case 'cssproperty':
                     let cssPropertyDoc = {};
                     cssPropertyDoc = handleClassJsDoc(cssPropertyDoc, jsDoc);
+                    delete cssPropertyDoc.type;
                     classDoc.cssProperties.push(cssPropertyDoc);
                     break;
                   case 'slot':


### PR DESCRIPTION
This

```js
import { LitElement } from 'lit-element';

/**
 * @cssprop {color} [--var-test=red] Test css custom prop
 */
export class MyElement extends LitElement {}
```

would output

```json
…
          "cssProperties": [
            {
              "type": {
                "text": "color"
              },
              "description": "Test css custom prop",
              "name": "--var-test",
              "default": "red"
            }
          ],
…
```

While the `CssCustomProperty` has no `type` in the schema: https://github.com/webcomponents/custom-elements-manifest/blob/a07ec8fd1aa921532bba0e8af21ee993f3bda2a5/schema.d.ts#L322-L354