### PR TITLE
chore: documentation on `@internal`/`@ignore`

### DIFF
--- a/docs/analyzer/getting-started.md
+++ b/docs/analyzer/getting-started.md
@@ -221,33 +221,44 @@ For all supported syntax, please check the [fixtures](https://github.com/open-wc
             "name": "MyElement",
             "cssProperties": [
               {
-                "description": "- Controls the color of foo",
+                "description": "Controls the color of foo",
                 "name": "--text-color"
               },
               {
-                "description": "- Controls the color of bar",
+                "description": "Controls the color of bar",
                 "name": "--background-color"
               }
             ],
             "cssParts": [
               {
-                "description": "- Styles the color of bar",
+                "description": "Styles the color of bar",
                 "name": "bar"
               }
             ],
             "slots": [
               {
-                "description": "- You can put some elements here",
+                "description": "You can put some elements here",
                 "name": "container"
               }
             ],
             "members": [
               {
                 "kind": "field",
+                "name": "foo",
+                "type": {
+                  "text": "string"
+                },
+                "default": "'foo'",
+                "reflects": true,
+                "attribute": "foo"
+              },
+              {
+                "kind": "field",
                 "name": "disabled",
                 "type": {
                   "text": "boolean"
                 },
+                "description": "disabled state",
                 "default": "true"
               },
               {
@@ -260,20 +271,35 @@ For all supported syntax, please check the [fixtures](https://github.com/open-wc
                 "name": "foo-changed",
                 "type": {
                   "text": "FooEvent"
-                }
+                },
+                "description": "foo-event - description"
+              }
+            ],
+            "attributes": [
+              {
+                "name": "foo",
+                "type": {
+                  "text": "string"
+                },
+                "default": "'foo'",
+                "fieldName": "foo"
               }
             ],
             "superclass": {
-              "name": "LitElement"
+              "name": "LitElement",
+              "package": "lit-element"
             },
-            "tagName": "my-element"
+            "tagName": "my-element",
+            "customElement": true
           },
           {
             "kind": "variable",
             "name": "someVariable",
             "type": {
               "text": "boolean"
-            }
+            },
+            "default": "true",
+            "description": "This will show up in the custom-elements.json too"
           }
         ],
         "exports": [

--- a/docs/analyzer/getting-started.md
+++ b/docs/analyzer/getting-started.md
@@ -169,6 +169,11 @@ For all supported syntax, please check the [fixtures](https://github.com/open-wc
      */
     foo = 'foo';
 
+    /**
+     * @internal
+     */
+    _privateThing = 1;
+
     constructor() {
       super();
       /** @type {boolean} - disabled state */
@@ -310,6 +315,7 @@ For all supported syntax, please check the [fixtures](https://github.com/open-wc
 | `@fires`,<br>`@event`         | Documents events that your component might fire    |
 | `@tag`,<br>`@tagname`         | Documents the name of your custom element          |
 | `@summary`                    | Documents a short summary                          |
+| `@internal`,<br>`@ignore`     | To omit documentation of internal details          |
 
 ```js
 /**


### PR DESCRIPTION
I was searching the docs for information on how to ignore certain fields in a custom element when generating the CEM.
I found the answer in a Slack thread, so I thought the docs could use an update on that topic 😜 


Also, the generated `custom-elements.json` example in the `getting-started.md` seemed to be a bit outdated.