### PR TITLE
docs(to-markdown): correct omitSections options case

### DIFF
--- a/packages/to-markdown/README.md
+++ b/packages/to-markdown/README.md
@@ -61,17 +61,17 @@ customElementsManifestToMarkdown(manifest, {
 
 The `omitSections` option is a `string[]` that controls which sections of a declaration's full entry in the manifest.json should be rendered in the final markdown output. The section names are:
 
-- mainHeading
-- superClass
+- main-heading
+- super-class
 - fields
 - methods
-- staticFields
-- staticMethods
+- static-fields
+- static-methods
 - slots
 - events
 - attributes
-- cssProperties
-- cssParts
+- css-properties
+- css-parts
 - mixins
 
 The following is an example config showing how to filter out a few sections:
@@ -80,7 +80,7 @@ The following is an example config showing how to filter out a few sections:
 customElementsManifestToMarkdown(manifest, {
   // static fields and static methods tables will not be present
   // in the markdown result
-  omitSections: [ 'staticFields', 'staticMethods' ]
+  omitSections: [ 'static-fields', 'static-methods' ]
 })
 ```
 


### PR DESCRIPTION
The docs for the `omitSections` options for `customElementsManifestToMarkdown` were displaying the wrong casing.

These are the SECTIONS listed in `lib/index.js`: 

```
const SECTIONS = {
  mainHeading: 'main-heading',
  superClass: 'super-class',
  fields: 'fields', 
  methods: 'methods',
  staticFields: 'static-fields',
  staticMethods: 'static-methods',
  slots: 'slots',
  events: 'events',
  attributes: 'attributes',
  cssProperties: 'css-properties',
  cssParts: 'css-parts',
  mixins: 'mixins'
}
```

The below fn in the same file parses the options passed in to see if they match the _values_ of the above object, and so should also be kebab-case, not camelCase:

```
function getOmittedConfig(type, omittedOptions) {
  // target will either be the declarations options object or the sections options object, depending on `type`
  const target = type === 'decl' ? Object.assign({}, DECLARATIONS) : Object.assign({}, SECTIONS);

  // rewrite target object with boolean values for comparison in nodes array
  // true if not omitted, false if omitted.
  Object.keys(target).forEach((omitted) => target[omitted] = !omittedOptions.includes(target[omitted]));
  return target;
}
```
