### PR TITLE
chore: renaming of fixture folders should not fail a test

### DIFF
--- a/packages/analyzer/fixtures/-default/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/-default/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "./fixtures/default/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -32,7 +32,7 @@
           "name": "my-element",
           "declaration": {
             "name": "MyElement",
-            "module": "./fixtures/default/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/-default/output.json
+++ b/packages/analyzer/fixtures/-default/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/default/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "mixin",
@@ -13,7 +13,7 @@
           "mixins": [
             {
               "name": "dedupeMixin",
-              "module": "fixtures/default/package/my-element.js"
+              "module": "package/my-element.js"
             }
           ]
         }
@@ -24,7 +24,7 @@
           "name": "ReexportedWrappedMixin",
           "declaration": {
             "name": "ReexportedWrappedMixin",
-            "module": "fixtures/default/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/class-attributes/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/class-attributes/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/class-attributes/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -102,7 +102,7 @@
           "name": "my-el",
           "declaration": {
             "name": "MyEl",
-            "module": "fixtures/class-attributes/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -110,7 +110,7 @@
           "name": "Foo",
           "declaration": {
             "name": "Foo",
-            "module": "fixtures/class-attributes/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/class-attributes/output.json
+++ b/packages/analyzer/fixtures/class-attributes/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/class-attributes/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -102,7 +102,7 @@
           "name": "my-el",
           "declaration": {
             "name": "MyEl",
-            "module": "fixtures/class-attributes/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -110,7 +110,7 @@
           "name": "Foo",
           "declaration": {
             "name": "Foo",
-            "module": "fixtures/class-attributes/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/class-fields/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/class-fields/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/class-fields/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -301,7 +301,7 @@
           "name": "my-el",
           "declaration": {
             "name": "MyEl",
-            "module": "fixtures/class-fields/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/class-fields/output.json
+++ b/packages/analyzer/fixtures/class-fields/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/class-fields/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -301,7 +301,7 @@
           "name": "my-el",
           "declaration": {
             "name": "MyEl",
-            "module": "fixtures/class-fields/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/class-jsdoc/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/class-jsdoc/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/class-jsdoc/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -105,7 +105,7 @@
           "name": "MyElement",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/class-jsdoc/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/class-jsdoc/output.json
+++ b/packages/analyzer/fixtures/class-jsdoc/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/class-jsdoc/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -105,7 +105,7 @@
           "name": "MyElement",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/class-jsdoc/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/custom-elements-define/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/custom-elements-define/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/custom-elements-define/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -63,7 +63,7 @@
           "name": "my-foo",
           "declaration": {
             "name": "MyFoo",
-            "module": "/fixtures/custom-elements-define/package/foo.js"
+            "module": "package/foo.js"
           }
         },
         {
@@ -79,7 +79,7 @@
           "name": "my-element",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/custom-elements-define/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -87,7 +87,7 @@
           "name": "my-window",
           "declaration": {
             "name": "MyWindow",
-            "module": "fixtures/custom-elements-define/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -95,7 +95,7 @@
           "name": "anon-1",
           "declaration": {
             "name": "anonymous_4",
-            "module": "fixtures/custom-elements-define/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -103,7 +103,7 @@
           "name": "anon-2",
           "declaration": {
             "name": "MyEl",
-            "module": "fixtures/custom-elements-define/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/custom-elements-define/output.json
+++ b/packages/analyzer/fixtures/custom-elements-define/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/custom-elements-define/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -63,7 +63,7 @@
           "name": "my-foo",
           "declaration": {
             "name": "MyFoo",
-            "module": "/fixtures/custom-elements-define/package/foo.js"
+            "module": "package/foo.js"
           }
         },
         {
@@ -79,7 +79,7 @@
           "name": "my-element",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/custom-elements-define/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -87,7 +87,7 @@
           "name": "my-window",
           "declaration": {
             "name": "MyWindow",
-            "module": "fixtures/custom-elements-define/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -95,7 +95,7 @@
           "name": "anon-1",
           "declaration": {
             "name": "anonymous_4",
-            "module": "fixtures/custom-elements-define/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -103,7 +103,7 @@
           "name": "anon-2",
           "declaration": {
             "name": "MyEl",
-            "module": "fixtures/custom-elements-define/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/events/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/events/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/events/package/bar.js",
+      "path": "package/bar.js",
       "declarations": [
         {
           "kind": "class",
@@ -37,7 +37,7 @@
           "name": "my-element",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/events/package/bar.js"
+            "module": "package/bar.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/events/output.json
+++ b/packages/analyzer/fixtures/events/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/events/package/bar.js",
+      "path": "package/bar.js",
       "declarations": [
         {
           "kind": "class",
@@ -37,7 +37,7 @@
           "name": "my-element",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/events/package/bar.js"
+            "module": "package/bar.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/functionLike/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/functionLike/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/functionLike/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "function",
@@ -254,7 +254,7 @@
           "name": "arrow1",
           "declaration": {
             "name": "arrow1",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -262,7 +262,7 @@
           "name": "arrow2",
           "declaration": {
             "name": "arrow2",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -270,7 +270,7 @@
           "name": "arrow3",
           "declaration": {
             "name": "arrow3",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -278,7 +278,7 @@
           "name": "arrow4",
           "declaration": {
             "name": "arrow4",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -286,7 +286,7 @@
           "name": "arrow5",
           "declaration": {
             "name": "arrow5",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -294,7 +294,7 @@
           "name": "arrow6",
           "declaration": {
             "name": "arrow6",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -302,7 +302,7 @@
           "name": "functionDeclaration1",
           "declaration": {
             "name": "functionDeclaration1",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -310,7 +310,7 @@
           "name": "functionDeclaration2",
           "declaration": {
             "name": "functionDeclaration2",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -318,7 +318,7 @@
           "name": "functionDeclaration3",
           "declaration": {
             "name": "functionDeclaration3",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -326,7 +326,7 @@
           "name": "functionDeclaration4",
           "declaration": {
             "name": "functionDeclaration4",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -334,7 +334,7 @@
           "name": "functionDeclaration5",
           "declaration": {
             "name": "functionDeclaration5",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -342,14 +342,14 @@
           "name": "functionDeclaration6",
           "declaration": {
             "name": "functionDeclaration6",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
           "name": "emptyReturn",
           "declaration": {
             "name": "emptyReturn",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           },
           "kind": "js"
         },
@@ -358,7 +358,7 @@
           "name": "MyEl",
           "declaration": {
             "name": "MyEl",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/functionLike/output.json
+++ b/packages/analyzer/fixtures/functionLike/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/functionLike/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "function",
@@ -254,7 +254,7 @@
           "name": "arrow1",
           "declaration": {
             "name": "arrow1",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -262,7 +262,7 @@
           "name": "arrow2",
           "declaration": {
             "name": "arrow2",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -270,7 +270,7 @@
           "name": "arrow3",
           "declaration": {
             "name": "arrow3",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -278,7 +278,7 @@
           "name": "arrow4",
           "declaration": {
             "name": "arrow4",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -286,7 +286,7 @@
           "name": "arrow5",
           "declaration": {
             "name": "arrow5",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -294,7 +294,7 @@
           "name": "arrow6",
           "declaration": {
             "name": "arrow6",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -302,7 +302,7 @@
           "name": "functionDeclaration1",
           "declaration": {
             "name": "functionDeclaration1",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -310,7 +310,7 @@
           "name": "functionDeclaration2",
           "declaration": {
             "name": "functionDeclaration2",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -318,7 +318,7 @@
           "name": "functionDeclaration3",
           "declaration": {
             "name": "functionDeclaration3",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -326,7 +326,7 @@
           "name": "functionDeclaration4",
           "declaration": {
             "name": "functionDeclaration4",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -334,7 +334,7 @@
           "name": "functionDeclaration5",
           "declaration": {
             "name": "functionDeclaration5",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -342,7 +342,7 @@
           "name": "functionDeclaration6",
           "declaration": {
             "name": "functionDeclaration6",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -350,7 +350,7 @@
           "name": "emptyReturn",
           "declaration": {
             "name": "emptyReturn",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -358,7 +358,7 @@
           "name": "MyEl",
           "declaration": {
             "name": "MyEl",
-            "module": "fixtures/functionLike/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/inheritance-mixins/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/inheritance-mixins/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-mixins/package/ModuleMixin.js",
+      "path": "package/ModuleMixin.js",
       "declarations": [
         {
           "kind": "mixin",
@@ -46,14 +46,14 @@
           "name": "ModuleMixin",
           "declaration": {
             "name": "ModuleMixin",
-            "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+            "module": "package/ModuleMixin.js"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-mixins/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "mixin",
@@ -106,7 +106,7 @@
               "name": "nestedMixinField",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -114,7 +114,7 @@
               "name": "nestedMixinMethod",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
@@ -132,7 +132,7 @@
               },
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
@@ -144,14 +144,14 @@
               "name": "nestedMixin-attr",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
           "mixins": [
             {
               "name": "NestedMixin",
-              "module": "fixtures/inheritance-mixins/package/my-element.js"
+              "module": "package/my-element.js"
             }
           ],
           "parameters": [
@@ -178,7 +178,7 @@
               "name": "moduleMixinField",
               "inheritedFrom": {
                 "name": "ModuleMixin",
-                "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+                "module": "package/ModuleMixin.js"
               }
             },
             {
@@ -186,7 +186,7 @@
               "name": "moduleMixinMethod",
               "inheritedFrom": {
                 "name": "ModuleMixin",
-                "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+                "module": "package/ModuleMixin.js"
               }
             },
             {
@@ -194,7 +194,7 @@
               "name": "mixinField",
               "inheritedFrom": {
                 "name": "MyMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -202,7 +202,7 @@
               "name": "mixinMethod",
               "inheritedFrom": {
                 "name": "MyMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -210,7 +210,7 @@
               "name": "nestedMixinField",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -218,7 +218,7 @@
               "name": "nestedMixinMethod",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
@@ -236,7 +236,7 @@
               },
               "inheritedFrom": {
                 "name": "ModuleMixin",
-                "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+                "module": "package/ModuleMixin.js"
               }
             },
             {
@@ -246,7 +246,7 @@
               },
               "inheritedFrom": {
                 "name": "MyMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -256,7 +256,7 @@
               },
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
@@ -268,32 +268,32 @@
               "name": "moduleMixin-attr",
               "inheritedFrom": {
                 "name": "ModuleMixin",
-                "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+                "module": "package/ModuleMixin.js"
               }
             },
             {
               "name": "mixin-attr",
               "inheritedFrom": {
                 "name": "MyMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
               "name": "nestedMixin-attr",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
           "mixins": [
             {
               "name": "ModuleMixin",
-              "module": "/fixtures/inheritance-mixins/package/ModuleMixin.js"
+              "module": "package/ModuleMixin.js"
             },
             {
               "name": "MyMixin",
-              "module": "fixtures/inheritance-mixins/package/my-element.js"
+              "module": "package/my-element.js"
             }
           ],
           "superclass": {
@@ -308,7 +308,7 @@
           "name": "NestedMixin",
           "declaration": {
             "name": "NestedMixin",
-            "module": "fixtures/inheritance-mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -316,7 +316,7 @@
           "name": "MyMixin",
           "declaration": {
             "name": "MyMixin",
-            "module": "fixtures/inheritance-mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -324,7 +324,7 @@
           "name": "MyElement",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/inheritance-mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/inheritance-mixins/output.json
+++ b/packages/analyzer/fixtures/inheritance-mixins/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-mixins/package/ModuleMixin.js",
+      "path": "package/ModuleMixin.js",
       "declarations": [
         {
           "kind": "mixin",
@@ -46,14 +46,14 @@
           "name": "ModuleMixin",
           "declaration": {
             "name": "ModuleMixin",
-            "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+            "module": "package/ModuleMixin.js"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-mixins/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "mixin",
@@ -106,7 +106,7 @@
               "name": "nestedMixinField",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -114,7 +114,7 @@
               "name": "nestedMixinMethod",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
@@ -132,7 +132,7 @@
               },
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
@@ -144,14 +144,14 @@
               "name": "nestedMixin-attr",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
           "mixins": [
             {
               "name": "NestedMixin",
-              "module": "fixtures/inheritance-mixins/package/my-element.js"
+              "module": "package/my-element.js"
             }
           ],
           "parameters": [
@@ -178,7 +178,7 @@
               "name": "moduleMixinField",
               "inheritedFrom": {
                 "name": "ModuleMixin",
-                "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+                "module": "package/ModuleMixin.js"
               }
             },
             {
@@ -186,7 +186,7 @@
               "name": "moduleMixinMethod",
               "inheritedFrom": {
                 "name": "ModuleMixin",
-                "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+                "module": "package/ModuleMixin.js"
               }
             },
             {
@@ -194,7 +194,7 @@
               "name": "mixinField",
               "inheritedFrom": {
                 "name": "MyMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -202,7 +202,7 @@
               "name": "mixinMethod",
               "inheritedFrom": {
                 "name": "MyMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -210,7 +210,7 @@
               "name": "nestedMixinField",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -218,7 +218,7 @@
               "name": "nestedMixinMethod",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
@@ -236,7 +236,7 @@
               },
               "inheritedFrom": {
                 "name": "ModuleMixin",
-                "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+                "module": "package/ModuleMixin.js"
               }
             },
             {
@@ -246,7 +246,7 @@
               },
               "inheritedFrom": {
                 "name": "MyMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
@@ -256,7 +256,7 @@
               },
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
@@ -268,32 +268,32 @@
               "name": "moduleMixin-attr",
               "inheritedFrom": {
                 "name": "ModuleMixin",
-                "module": "fixtures/inheritance-mixins/package/ModuleMixin.js"
+                "module": "package/ModuleMixin.js"
               }
             },
             {
               "name": "mixin-attr",
               "inheritedFrom": {
                 "name": "MyMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             },
             {
               "name": "nestedMixin-attr",
               "inheritedFrom": {
                 "name": "NestedMixin",
-                "module": "fixtures/inheritance-mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ],
           "mixins": [
             {
               "name": "ModuleMixin",
-              "module": "/fixtures/inheritance-mixins/package/ModuleMixin.js"
+              "module": "package/ModuleMixin.js"
             },
             {
               "name": "MyMixin",
-              "module": "fixtures/inheritance-mixins/package/my-element.js"
+              "module": "package/my-element.js"
             }
           ],
           "superclass": {
@@ -308,7 +308,7 @@
           "name": "NestedMixin",
           "declaration": {
             "name": "NestedMixin",
-            "module": "fixtures/inheritance-mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -316,7 +316,7 @@
           "name": "MyMixin",
           "declaration": {
             "name": "MyMixin",
-            "module": "fixtures/inheritance-mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -324,7 +324,7 @@
           "name": "MyElement",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/inheritance-mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/inheritance-superclass/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/inheritance-superclass/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-superclass/package/BatchingElement.js",
+      "path": "package/BatchingElement.js",
       "declarations": [
         {
           "kind": "class",
@@ -53,14 +53,14 @@
           "name": "BatchingElement",
           "declaration": {
             "name": "BatchingElement",
-            "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+            "module": "package/BatchingElement.js"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-superclass/package/implements-element.ts",
+      "path": "package/implements-element.ts",
       "declarations": [
         {
           "kind": "class",
@@ -84,7 +84,7 @@
               "name": "superClassField",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             },
             {
@@ -92,7 +92,7 @@
               "name": "superClassMethod",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             },
             {
@@ -104,7 +104,7 @@
               "default": "'hello'",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
@@ -122,7 +122,7 @@
               },
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
@@ -134,13 +134,13 @@
               "name": "superClass-attr",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
           "superclass": {
             "name": "BatchingElement",
-            "module": "/fixtures/inheritance-superclass/package/BatchingElement"
+            "module": "package/BatchingElement"
           }
         }
       ],
@@ -150,14 +150,14 @@
           "name": "ImplementsElement",
           "declaration": {
             "name": "ImplementsElement",
-            "module": "fixtures/inheritance-superclass/package/implements-element.ts"
+            "module": "package/implements-element.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-superclass/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -181,7 +181,7 @@
               "default": "'bye'",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             },
             {
@@ -189,7 +189,7 @@
               "name": "superClassField",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             },
             {
@@ -197,7 +197,7 @@
               "name": "superClassMethod",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
@@ -215,7 +215,7 @@
               },
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
@@ -227,13 +227,13 @@
               "name": "superClass-attr",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
           "superclass": {
             "name": "BatchingElement",
-            "module": "/fixtures/inheritance-superclass/package/BatchingElement.js"
+            "module": "package/BatchingElement.js"
           }
         }
       ],
@@ -243,7 +243,7 @@
           "name": "MyElement",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/inheritance-superclass/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/inheritance-superclass/output.json
+++ b/packages/analyzer/fixtures/inheritance-superclass/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-superclass/package/BatchingElement.js",
+      "path": "package/BatchingElement.js",
       "declarations": [
         {
           "kind": "class",
@@ -53,14 +53,14 @@
           "name": "BatchingElement",
           "declaration": {
             "name": "BatchingElement",
-            "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+            "module": "package/BatchingElement.js"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-superclass/package/implements-element.ts",
+      "path": "package/implements-element.ts",
       "declarations": [
         {
           "kind": "class",
@@ -84,7 +84,7 @@
               "name": "superClassField",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             },
             {
@@ -92,7 +92,7 @@
               "name": "superClassMethod",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             },
             {
@@ -104,7 +104,7 @@
               "default": "'hello'",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
@@ -122,7 +122,7 @@
               },
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
@@ -134,13 +134,13 @@
               "name": "superClass-attr",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
           "superclass": {
             "name": "BatchingElement",
-            "module": "/fixtures/inheritance-superclass/package/BatchingElement"
+            "module": "package/BatchingElement"
           }
         }
       ],
@@ -150,14 +150,14 @@
           "name": "ImplementsElement",
           "declaration": {
             "name": "ImplementsElement",
-            "module": "fixtures/inheritance-superclass/package/implements-element.ts"
+            "module": "package/implements-element.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "fixtures/inheritance-superclass/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -181,7 +181,7 @@
               "default": "'bye'",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             },
             {
@@ -189,7 +189,7 @@
               "name": "superClassField",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             },
             {
@@ -197,7 +197,7 @@
               "name": "superClassMethod",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
@@ -215,7 +215,7 @@
               },
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
@@ -227,13 +227,13 @@
               "name": "superClass-attr",
               "inheritedFrom": {
                 "name": "BatchingElement",
-                "module": "fixtures/inheritance-superclass/package/BatchingElement.js"
+                "module": "package/BatchingElement.js"
               }
             }
           ],
           "superclass": {
             "name": "BatchingElement",
-            "module": "/fixtures/inheritance-superclass/package/BatchingElement.js"
+            "module": "package/BatchingElement.js"
           }
         }
       ],
@@ -243,7 +243,7 @@
           "name": "MyElement",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/inheritance-superclass/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/jsdoc-ignore-internal/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/jsdoc-ignore-internal/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/jsdoc-ignore-internal/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "variable",
@@ -41,7 +41,7 @@
           "name": "variable",
           "declaration": {
             "name": "variable",
-            "module": "fixtures/jsdoc-ignore-internal/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -49,7 +49,7 @@
           "name": "IncludeMe",
           "declaration": {
             "name": "IncludeMe",
-            "module": "fixtures/jsdoc-ignore-internal/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -57,7 +57,7 @@
           "name": "include-me",
           "declaration": {
             "name": "IncludeMe",
-            "module": "fixtures/jsdoc-ignore-internal/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/jsdoc-ignore-internal/output.json
+++ b/packages/analyzer/fixtures/jsdoc-ignore-internal/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/jsdoc-ignore-internal/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "variable",
@@ -41,7 +41,7 @@
           "name": "variable",
           "declaration": {
             "name": "variable",
-            "module": "fixtures/jsdoc-ignore-internal/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -49,7 +49,7 @@
           "name": "IncludeMe",
           "declaration": {
             "name": "IncludeMe",
-            "module": "fixtures/jsdoc-ignore-internal/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -57,7 +57,7 @@
           "name": "include-me",
           "declaration": {
             "name": "IncludeMe",
-            "module": "fixtures/jsdoc-ignore-internal/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/mixins/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/mixins/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/mixins/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "mixin",
@@ -76,7 +76,7 @@
           "mixins": [
             {
               "name": "InternalMixin",
-              "module": "fixtures/mixins/package/my-element.js"
+              "module": "package/my-element.js"
             }
           ],
           "superclass": {
@@ -93,7 +93,7 @@
               "default": "1",
               "inheritedFrom": {
                 "name": "InternalMixin",
-                "module": "fixtures/mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ]
@@ -105,7 +105,7 @@
           "mixins": [
             {
               "name": "BarMixin",
-              "module": "/fixtures/mixins/package/bar-mixin.js"
+              "module": "package/bar-mixin.js"
             },
             {
               "name": "dedupeMixin",
@@ -131,7 +131,7 @@
           "name": "ArrowFunctionMixin",
           "declaration": {
             "name": "ArrowFunctionMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -139,7 +139,7 @@
           "name": "FunctionDeclarationMixin",
           "declaration": {
             "name": "FunctionDeclarationMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -147,7 +147,7 @@
           "name": "ReturnValMixin",
           "declaration": {
             "name": "ReturnValMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -155,7 +155,7 @@
           "name": "ReturnValArrowMixin",
           "declaration": {
             "name": "ReturnValArrowMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -163,7 +163,7 @@
           "name": "InternalClass",
           "declaration": {
             "name": "InternalClass",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -171,7 +171,7 @@
           "name": "ReexportedWrappedMixin",
           "declaration": {
             "name": "ReexportedWrappedMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/mixins/output.json
+++ b/packages/analyzer/fixtures/mixins/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/mixins/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "mixin",
@@ -76,7 +76,7 @@
           "mixins": [
             {
               "name": "InternalMixin",
-              "module": "fixtures/mixins/package/my-element.js"
+              "module": "package/my-element.js"
             }
           ],
           "superclass": {
@@ -93,7 +93,7 @@
               "default": "1",
               "inheritedFrom": {
                 "name": "InternalMixin",
-                "module": "fixtures/mixins/package/my-element.js"
+                "module": "package/my-element.js"
               }
             }
           ]
@@ -105,7 +105,7 @@
           "mixins": [
             {
               "name": "BarMixin",
-              "module": "/fixtures/mixins/package/bar-mixin.js"
+              "module": "package/bar-mixin.js"
             },
             {
               "name": "dedupeMixin",
@@ -131,7 +131,7 @@
           "name": "ArrowFunctionMixin",
           "declaration": {
             "name": "ArrowFunctionMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -139,7 +139,7 @@
           "name": "FunctionDeclarationMixin",
           "declaration": {
             "name": "FunctionDeclarationMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -147,7 +147,7 @@
           "name": "ReturnValMixin",
           "declaration": {
             "name": "ReturnValMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -155,7 +155,7 @@
           "name": "ReturnValArrowMixin",
           "declaration": {
             "name": "ReturnValArrowMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -163,7 +163,7 @@
           "name": "InternalClass",
           "declaration": {
             "name": "InternalClass",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -171,7 +171,7 @@
           "name": "ReexportedWrappedMixin",
           "declaration": {
             "name": "ReexportedWrappedMixin",
-            "module": "fixtures/mixins/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/plugin-catalyst/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/plugin-catalyst/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/plugin-catalyst/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -47,7 +47,7 @@
           "name": "hello-world",
           "declaration": {
             "name": "HelloWorldElement",
-            "module": "fixtures/plugin-catalyst/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/plugin-catalyst/output.json
+++ b/packages/analyzer/fixtures/plugin-catalyst/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/plugin-catalyst/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -47,7 +47,7 @@
           "name": "hello-world",
           "declaration": {
             "name": "HelloWorldElement",
-            "module": "fixtures/plugin-catalyst/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/plugin-fast/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/plugin-fast/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/plugin-fast/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -52,7 +52,7 @@
           "name": "NameTag",
           "declaration": {
             "name": "NameTag",
-            "module": "fixtures/plugin-fast/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -60,7 +60,7 @@
           "name": "name-tag",
           "declaration": {
             "name": "NameTag",
-            "module": "fixtures/plugin-fast/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/plugin-fast/output.json
+++ b/packages/analyzer/fixtures/plugin-fast/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/plugin-fast/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -52,7 +52,7 @@
           "name": "NameTag",
           "declaration": {
             "name": "NameTag",
-            "module": "fixtures/plugin-fast/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -60,7 +60,7 @@
           "name": "name-tag",
           "declaration": {
             "name": "NameTag",
-            "module": "fixtures/plugin-fast/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/plugin-lit/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/plugin-lit/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/plugin-lit/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -201,7 +201,7 @@
           "name": "my-element",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/plugin-lit/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -209,7 +209,7 @@
           "name": "InputMixin",
           "declaration": {
             "name": "InputMixin",
-            "module": "fixtures/plugin-lit/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/plugin-lit/output.json
+++ b/packages/analyzer/fixtures/plugin-lit/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/plugin-lit/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -201,7 +201,7 @@
           "name": "my-element",
           "declaration": {
             "name": "MyElement",
-            "module": "fixtures/plugin-lit/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -209,7 +209,7 @@
           "name": "InputMixin",
           "declaration": {
             "name": "InputMixin",
-            "module": "fixtures/plugin-lit/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/plugin-stencil/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/plugin-stencil/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/plugin-stencil/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -106,7 +106,7 @@
           "name": "TodoList",
           "declaration": {
             "name": "TodoList",
-            "module": "fixtures/plugin-stencil/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -114,7 +114,7 @@
           "name": "todo-list",
           "declaration": {
             "name": "TodoList",
-            "module": "fixtures/plugin-stencil/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/plugin-stencil/output.json
+++ b/packages/analyzer/fixtures/plugin-stencil/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/plugin-stencil/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "class",
@@ -105,7 +105,7 @@
           "name": "TodoList",
           "declaration": {
             "name": "TodoList",
-            "module": "fixtures/plugin-stencil/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -113,7 +113,7 @@
           "name": "todo-list",
           "declaration": {
             "name": "TodoList",
-            "module": "fixtures/plugin-stencil/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/variables/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/variables/fixture/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/variables/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "variable",
@@ -78,7 +78,7 @@
           "name": "var1",
           "declaration": {
             "name": "var1",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -86,7 +86,7 @@
           "name": "var2",
           "declaration": {
             "name": "var2",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -94,7 +94,7 @@
           "name": "var3B",
           "declaration": {
             "name": "var3A",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -102,7 +102,7 @@
           "name": "var4",
           "declaration": {
             "name": "var4",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -110,7 +110,7 @@
           "name": "var5",
           "declaration": {
             "name": "var5",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -118,7 +118,7 @@
           "name": "var6",
           "declaration": {
             "name": "var6",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -126,7 +126,7 @@
           "name": "var7",
           "declaration": {
             "name": "var7",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -134,7 +134,7 @@
           "name": "function1",
           "declaration": {
             "name": "function1",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -142,7 +142,7 @@
           "name": "Class1",
           "declaration": {
             "name": "Class1",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -150,7 +150,7 @@
           "name": "typeinferrence",
           "declaration": {
             "name": "typeinferrence",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -158,7 +158,7 @@
           "name": "asConst",
           "declaration": {
             "name": "asConst",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -166,7 +166,7 @@
           "name": "asConstRef",
           "declaration": {
             "name": "asConstRef",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/variables/output.json
+++ b/packages/analyzer/fixtures/variables/output.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "fixtures/variables/package/my-element.js",
+      "path": "package/my-element.js",
       "declarations": [
         {
           "kind": "variable",
@@ -78,7 +78,7 @@
           "name": "var1",
           "declaration": {
             "name": "var1",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -86,7 +86,7 @@
           "name": "var2",
           "declaration": {
             "name": "var2",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -94,7 +94,7 @@
           "name": "var3B",
           "declaration": {
             "name": "var3A",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -102,7 +102,7 @@
           "name": "var4",
           "declaration": {
             "name": "var4",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -110,7 +110,7 @@
           "name": "var5",
           "declaration": {
             "name": "var5",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -118,7 +118,7 @@
           "name": "var6",
           "declaration": {
             "name": "var6",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -126,7 +126,7 @@
           "name": "var7",
           "declaration": {
             "name": "var7",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -134,7 +134,7 @@
           "name": "function1",
           "declaration": {
             "name": "function1",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -142,7 +142,7 @@
           "name": "Class1",
           "declaration": {
             "name": "Class1",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -150,7 +150,7 @@
           "name": "typeinferrence",
           "declaration": {
             "name": "typeinferrence",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -158,7 +158,7 @@
           "name": "asConst",
           "declaration": {
             "name": "asConst",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         },
         {
@@ -166,7 +166,7 @@
           "name": "asConstRef",
           "declaration": {
             "name": "asConstRef",
-            "module": "fixtures/variables/package/my-element.js"
+            "module": "package/my-element.js"
           }
         }
       ]

--- a/packages/analyzer/test/integration.test.js
+++ b/packages/analyzer/test/integration.test.js
@@ -16,6 +16,24 @@ if (runSingle) {
   testCases = [runSingle];
 }
 
+const stripRegex = /\.?\/?fixtures\/(.*?)\//;
+function stripFixturePaths(cem, testCase) {
+  if (typeof cem === 'object') {
+    Object.keys(cem).forEach(key => {
+      cem[key] = stripFixturePaths(cem[key], testCase);
+    });
+  }
+  if (Array.isArray(cem)) {
+    cem.forEach(key => {
+      cem[key] = stripFixturePaths(cem[key], testCase);
+    });
+  }
+  if (typeof cem === 'string') {
+    cem = cem.replace(stripRegex, '');
+  }
+  return cem;
+}
+
 describe('@CEM/A', ({it}) => {
   testCases.forEach(testCase => {
     if(testCase.startsWith('-')) {
@@ -50,8 +68,9 @@ describe('@CEM/A', ({it}) => {
           const config = await import(manifestPathFileURL);
           plugins = [...config.default.plugins];
         } catch {}
-    
+
         const result = create({modules, plugins});
+        stripFixturePaths(result, testCase); // adjusts result
     
         fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
     

--- a/plugins/readme/.gitignore
+++ b/plugins/readme/.gitignore
@@ -1,0 +1,5 @@
+dist/
+.DS_Store
+
+## Rocket ignore files
+node_modules/

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,19 @@
   resolved "https://registry.yarnpkg.com/@bundled-es-modules/message-format/-/message-format-6.0.4.tgz#232da6877adb960f6c8f598c72588a84352de147"
   integrity sha512-NGUoPxqsBzDwvRhY3A3L/AhS1hzS9OWappfyDOyCwE7G3W4ua28gau7QwvJz7QzA6ArbAdeb8c1mLjvd1WUFAA==
 
+"@custom-elements-manifest/to-markdown@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/to-markdown/-/to-markdown-0.0.13.tgz#c479e8c29d7febc51c83d3a7bb7ad86dbd3789d5"
+  integrity sha512-YuuMFtNoncbIBvFMO9AUA2oTQdUHyCPw0ejIKXZIoK5fh1xTWL0yYd61vPDea2UAuRTzKbnOUSxkevDi4dGlPw==
+  dependencies:
+    mdast-builder "^1.1.1"
+    mdast-util-from-markdown "^1.0.0"
+    mdast-util-gfm "^1.0.0"
+    mdast-util-to-markdown "^1.0.1"
+    remark-gfm "^1.0.0"
+    remark-stringify "^9.0.1"
+    unified "^9.2.1"
+
 "@lion/accordion@^0.6.1":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@lion/accordion/-/accordion-0.6.2.tgz#3bfb4ddd2a88a772573d970d3a53b941b04338d6"
@@ -2838,6 +2851,13 @@ decamelize@^1.0.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decode-named-character-reference@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.1.tgz#57b2bd9112659cacbc449d3577d7dadb8e1f3d1b"
+  integrity sha512-YV/0HQHreRwKb7uBopyIkLG17jG6Sv2qUchk9qSoVJ2f+flwRsPNBO0hAnjt6mTNYUT+vw9Gy2ihXg4sUWPi2w==
+  dependencies:
+    character-entities "^2.0.0"
 
 decompress-response@^3.3.0:
   version "3.3.0"
@@ -4949,6 +4969,24 @@ mdast-util-from-markdown@^0.8.0:
     micromark "~2.11.0"
     parse-entities "^2.0.0"
     unist-util-stringify-position "^2.0.0"
+
+mdast-util-from-markdown@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz#84df2924ccc6c995dec1e2368b2b208ad0a76268"
+  integrity sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    mdast-util-to-string "^3.1.0"
+    micromark "^3.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-decode-string "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-stringify-position "^3.0.0"
+    uvu "^0.5.0"
 
 mdast-util-from-markdown@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## What I did

1. filter out fixture paths when comparing
2. this enables you to rename a folder e.g. for example add a `+` in front to only run the single test and the test will still succeed