### PR TITLE
fix(analyzer): filter out internal manifests

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Release 0.6.3
+- Filter out internal manifests
+
+## Release 0.6.2
+- Add --quiet cli parameter
+
 ## Release 0.6.1
 - Re-add `#!/usr/bin/env node` to bin file
 

--- a/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/fixture/custom-elements.json
@@ -17,7 +17,7 @@
               "type": {
                 "text": "string"
               },
-              "default": "'otherValueThanProp'",
+              "default": "'prop'",
               "inheritedFrom": {
                 "name": "MyClass",
                 "module": "MyClass.js"
@@ -71,6 +71,30 @@
           "declaration": {
             "name": "MyElement",
             "module": "index.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "internalFile.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "internalVar",
+          "type": {
+            "text": "string"
+          },
+          "default": "'internalVar'"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "internalVar",
+          "declaration": {
+            "name": "internalVar",
+            "module": "internalFile.js"
           }
         }
       ]

--- a/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/monorepo/packages/to-be-analyzed-pkg/index.js
+++ b/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/monorepo/packages/to-be-analyzed-pkg/index.js
@@ -1,10 +1,11 @@
 import { MyMixin } from '@mono/sibling-pkg';
 import { MyClass } from 'ext-pkg-without-export-map';
+import { internalVar } from './internalFile.js';
 
 export class MyElement extends MyMixin(MyClass) {
   constructor() {
     super();
 
-    this.extClassProp = 'otherValueThanProp';
+    this.extClassProp = 'otherValueThanProp-' + internalVar;
   }
 }

--- a/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/monorepo/packages/to-be-analyzed-pkg/internalFile.js
+++ b/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/monorepo/packages/to-be-analyzed-pkg/internalFile.js
@@ -1,0 +1,2 @@
+// This file will be found by find-depencies, and it should be filtered out in find-external-manifests
+export const internalVar = 'internalVar';

--- a/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/output.json
+++ b/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/output.json
@@ -17,7 +17,7 @@
               "type": {
                 "text": "string"
               },
-              "default": "'otherValueThanProp'",
+              "default": "'prop'",
               "inheritedFrom": {
                 "name": "MyClass",
                 "module": "MyClass.js"
@@ -71,6 +71,30 @@
           "declaration": {
             "name": "MyElement",
             "module": "index.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "internalFile.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "internalVar",
+          "type": {
+            "text": "string"
+          },
+          "default": "'internalVar'"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "internalVar",
+          "declaration": {
+            "name": "internalVar",
+            "module": "internalFile.js"
           }
         }
       ]

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@custom-elements-manifest/analyzer",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "",
   "license": "MIT",
   "type": "module",

--- a/packages/analyzer/src/utils/find-external-manifests.js
+++ b/packages/analyzer/src/utils/find-external-manifests.js
@@ -13,14 +13,20 @@ import { findDependencies, splitPath } from '@custom-elements-manifest/find-depe
  *  basePath?: string,
  * }} [options]
  */
-export async function findExternalManifests(paths, options) {
+export async function findExternalManifests(paths, {basePath = process.cwd(), nodeModulesDepth}) {
   /** @type {Package[]} */
   const cemsToMerge = [];
   const visited = new Set();
 
-  const dependencies = await findDependencies(paths, options);
+  const dependencies = await findDependencies(paths, {basePath, nodeModulesDepth});
 
   dependencies?.forEach((dependencyPath) => {
+    const isCurrentPackageRegex = new RegExp(`^${basePath}\\${path.sep}(?!.*node_modules).*`);
+    if (isCurrentPackageRegex.test(dependencyPath)) {
+      // Make sure that we do not look for custom-elements.json in our own package
+      return;
+    }
+
     const { packageRoot, packageName } = splitPath(dependencyPath);
 
     if(visited.has(packageName)) return;


### PR DESCRIPTION
When running the latest release in Lion, we found that it breaks for packages that have internal references (it tries to read custom-elements.json that does not exist yet).


These few lines of code in 'find-external-manifests.js' fix this