### PR TITLE
feat: Lit - extract type from static properties

### DIFF
--- a/packages/analyzer/fixtures/07-plugin-lit/01-basic/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/07-plugin-lit/01-basic/fixture/custom-elements.json
@@ -64,18 +64,27 @@
               "kind": "field",
               "name": "prop2",
               "privacy": "public",
+              "type": {
+                "text": "boolean"
+              },
               "attribute": "prop2"
             },
             {
               "kind": "field",
               "name": "attr",
               "privacy": "public",
+              "type": {
+                "text": "string"
+              },
               "attribute": "my-attr"
             },
             {
               "kind": "field",
               "name": "noAttr",
-              "privacy": "public"
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              }
             },
             {
               "kind": "field",
@@ -90,6 +99,9 @@
               "kind": "field",
               "name": "reflect",
               "privacy": "public",
+              "type": {
+                "text": "boolean"
+              },
               "attribute": "reflect",
               "reflects": true
             },
@@ -97,6 +109,9 @@
               "kind": "field",
               "name": "reflect2",
               "privacy": "public",
+              "type": {
+                "text": "boolean"
+              },
               "attribute": "reflect-2",
               "reflects": true
             }
@@ -104,6 +119,9 @@
           "attributes": [
             {
               "name": "my-attr",
+              "type": {
+                "text": "string"
+              },
               "fieldName": "attr"
             },
             {
@@ -141,6 +159,9 @@
             },
             {
               "name": "prop2",
+              "type": {
+                "text": "boolean"
+              },
               "fieldName": "prop2"
             },
             {
@@ -152,10 +173,16 @@
             },
             {
               "name": "reflect",
+              "type": {
+                "text": "boolean"
+              },
               "fieldName": "reflect"
             },
             {
               "name": "reflect-2",
+              "type": {
+                "text": "boolean"
+              },
               "fieldName": "reflect2"
             }
           ],

--- a/packages/analyzer/fixtures/07-plugin-lit/01-basic/output.json
+++ b/packages/analyzer/fixtures/07-plugin-lit/01-basic/output.json
@@ -64,18 +64,27 @@
               "kind": "field",
               "name": "prop2",
               "privacy": "public",
+              "type": {
+                "text": "boolean"
+              },
               "attribute": "prop2"
             },
             {
               "kind": "field",
               "name": "attr",
               "privacy": "public",
+              "type": {
+                "text": "string"
+              },
               "attribute": "my-attr"
             },
             {
               "kind": "field",
               "name": "noAttr",
-              "privacy": "public"
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              }
             },
             {
               "kind": "field",
@@ -90,6 +99,9 @@
               "kind": "field",
               "name": "reflect",
               "privacy": "public",
+              "type": {
+                "text": "boolean"
+              },
               "attribute": "reflect",
               "reflects": true
             },
@@ -97,6 +109,9 @@
               "kind": "field",
               "name": "reflect2",
               "privacy": "public",
+              "type": {
+                "text": "boolean"
+              },
               "attribute": "reflect-2",
               "reflects": true
             }
@@ -104,6 +119,9 @@
           "attributes": [
             {
               "name": "my-attr",
+              "type": {
+                "text": "string"
+              },
               "fieldName": "attr"
             },
             {
@@ -141,6 +159,9 @@
             },
             {
               "name": "prop2",
+              "type": {
+                "text": "boolean"
+              },
               "fieldName": "prop2"
             },
             {
@@ -152,10 +173,16 @@
             },
             {
               "name": "reflect",
+              "type": {
+                "text": "boolean"
+              },
               "fieldName": "reflect"
             },
             {
               "name": "reflect-2",
+              "type": {
+                "text": "boolean"
+              },
               "fieldName": "reflect2"
             }
           ],

--- a/packages/analyzer/src/features/framework-plugins/lit/static-properties.js
+++ b/packages/analyzer/src/features/framework-plugins/lit/static-properties.js
@@ -7,6 +7,7 @@ import {
   getPropertiesObject,
   getAttributeName,
   reflects,
+  getType,
 } from './utils.js';
 
 import { extractMixinNodes, isMixin } from '../../../utils/mixins.js';
@@ -58,6 +59,12 @@ function handleStaticProperties(classNode, moduleDoc, context, mixinName = null)
           name: property?.name?.getText() || '',
           privacy: 'public',
         };
+
+        const type = getType(property);
+        if (type) {
+          classMember.type = { text: type }
+        }
+
         classMember = handleJsDoc(classMember, property);
 
         const memberIndex = currClass?.members?.findIndex(field => field.name === classMember.name);

--- a/packages/analyzer/src/features/framework-plugins/lit/utils.js
+++ b/packages/analyzer/src/features/framework-plugins/lit/utils.js
@@ -26,6 +26,16 @@ export function reflects(node) {
   return result;
 }
 
+export function getType(node) {
+  let result = false;
+  (node?.initializer || node)?.properties?.forEach((property) => {
+    if (property.name.text === 'type') {
+      result = property.initializer.text.toLowerCase();
+    }
+  });
+  return result;
+}
+
 export function getAttributeName(node) {
   let result = false;
   (node?.initializer || node)?.properties?.forEach((property) => {


### PR DESCRIPTION
Hi, 

I expected that `npx cem analyze --litelement` would extract types from static properties without any additional `jsdoc` comments.

```js
class MyElement extends LitElement {
  static get properties() {
    return {
      name: { type: String },
      active: { type: Boolean },
    }
  }
```

- [x] Implemented extract type feature
- [x] Updated tests
- [x] Tested manually with `api-viewer-element`

The benefits are:
- More types in documentation out of the box,
- and if you are using [api-viewer-element](https://github.com/open-wc/api-viewer-element) more knobs works automatically

I have down-cased type to be the same as others and that the knobs are working in `api-viewer-element`.