### PR TITLE
Expose typescript for programatic use

### DIFF
--- a/packages/analyzer/cem.js
+++ b/packages/analyzer/cem.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { cli } from './cli.js';
+
+cli();

--- a/packages/analyzer/index.js
+++ b/packages/analyzer/index.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
-import { cli } from './cli.js';
-
-cli();
+export { create } from './src/create.js';
+// Export ts to avoid version missmatch when using the create() method programatically 
+export { default as ts } from 'typescript';

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "types": "index.d.ts",
   "bin": {
-    "custom-elements-manifest": "./index.js",
-    "cem": "./index.js"
+    "custom-elements-manifest": "./cem.js",
+    "cem": "./cem.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will avoid typescript version mismatch when using the analyzer programatically between the internal version and the user version of typescript.