### PR TITLE
fix: add support for globalThis.customElements

### DIFF
--- a/packages/analyzer/src/utils/ast-helpers.js
+++ b/packages/analyzer/src/utils/ast-helpers.js
@@ -18,7 +18,7 @@ export const isReturnStatement = statement => statement?.kind === ts.SyntaxKind.
  * @example customElements.define('my-el', MyEl);
  * @example window.customElements.define('my-el', MyEl);
  */
-export const isCustomElementsDefineCall = node => (node?.expression?.getText() === 'customElements' || node?.expression?.getText() === 'window.customElements') && node?.name?.getText() === 'define' && node?.parent?.kind === ts.SyntaxKind.CallExpression;
+export const isCustomElementsDefineCall = node => (node?.expression?.getText() === 'customElements' || node?.expression?.getText() === 'window.customElements' || node?.expression?.getText() === 'globalThis.customElements') && node?.name?.getText() === 'define' && node?.parent?.kind === ts.SyntaxKind.CallExpression;
 
 /**
  * @example @attr


### PR DESCRIPTION
thanks for a great package!

this adds support for using `globalThis.customElements.define()` which could be more and more used in the future.

we recently changed our library to use `globalThis.customElements.define()` to avoid polluting `window`
https://github.com/muxinc/media-chrome/commit/f620c1ea37c6618d9c621a983baa088e8f9b6f0d

and the `tagName`'s disappeared from the custom elements manifest...