### PR TITLE
Add support for custom states

### DIFF
--- a/docs/analyzer/getting-started.md
+++ b/docs/analyzer/getting-started.md
@@ -331,18 +331,19 @@ For all supported syntax, please check the [fixtures](https://github.com/open-wc
 
 ### Supported JSDoc
 
-| JSDoc                         | Description                                        |
-| ----------------------------- | -------------------------------------------------- |
-| `@attr`, <br>`@attribute`     | Documents attributes for your custom element       |
-| `@prop`, <br>`@property `     | Documents properties for your custom element       |
-| `@part`,<br>`@csspart`        | Documents your custom elements Shadow Parts        |
-| `@slot`                       | Documents the Slots used in your components        |
-| `@cssprop`,<br>`@cssproperty` | Documents CSS Custom Properties for your component |
-| `@fires`,<br>`@event`         | Documents events that your component might fire    |
-| `@tag`,<br>`@tagname`         | Documents the name of your custom element          |
-| `@summary`                    | Documents a short summary                          |
-| `@internal`,<br>`@ignore`     | To omit documentation of internal details          |
-| `@default`                    | Documents the default value for a property         |
+| JSDoc                         | Description                                                                       |
+| ----------------------------- | --------------------------------------------------------------------------------- |
+| `@attr`, <br>`@attribute`     | Documents attributes for your custom element                                      |
+| `@prop`, <br>`@property `     | Documents properties for your custom element                                      |
+| `@part`,<br>`@csspart`        | Documents your custom elements Shadow Parts                                       |
+| `@slot`                       | Documents the Slots used in your components                                       |
+| `@cssprop`,<br>`@cssproperty` | Documents CSS Custom Properties for your component                                |
+| `@cssState`                   | Documents the custom CSS state of your custom element when using ElementInternals |
+| `@fires`,<br>`@event`         | Documents events that your component might fire                                   |
+| `@tag`,<br>`@tagname`         | Documents the name of your custom element                                         |
+| `@summary`                    | Documents a short summary                                                         |
+| `@internal`,<br>`@ignore`     | To omit documentation of internal details                                         |
+| `@default`                    | Documents the default value for a property                                        |
 
 ```js
 /**

--- a/packages/analyzer/fixtures/01-class/05-custom-states/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/01-class/05-custom-states/fixture/custom-elements.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "cssStates": [
+            {
+              "description": "Applies when the element is active",
+              "name": "active"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "MyElement",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/01-class/05-custom-states/output.json
+++ b/packages/analyzer/fixtures/01-class/05-custom-states/output.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "cssStates": [
+            {
+              "description": "Applies when the element is active",
+              "name": "active"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "MyElement",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/01-class/05-custom-states/package/my-element.js
+++ b/packages/analyzer/fixtures/01-class/05-custom-states/package/my-element.js
@@ -1,0 +1,5 @@
+// typedef should be ignored
+/**
+ * @cssState active - Applies when the element is active
+ */
+export class MyElement extends HTMLElement {}

--- a/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
+++ b/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
@@ -87,6 +87,13 @@ export function classJsDocPlugin() {
                   case 'element':
                     classDoc.tagName = jsDoc?.name || '';
                     break;
+                  case 'state':
+                  case 'customState':
+                    console.log("CUSTOM STATE")
+                    let statePropertyDoc = {};
+                    statePropertyDoc = handleClassJsDoc(statePropertyDoc, jsDoc);
+                    classDoc.customStates.push(statePropertyDoc);
+                    break;
                   case 'deprecated':
                     classDoc.deprecated = jsDoc?.name ? `${jsDoc.name} ${jsDoc?.description}`.trim() : "true";
                     break;

--- a/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
+++ b/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
@@ -35,7 +35,7 @@ export function classJsDocPlugin() {
               if(parsedJsDoc?.tags?.some(tag => tag?.tag === 'typedef')) return;
 
               parsedJsDoc?.tags?.forEach(jsDoc => {
-                switch(jsDoc.tag) {
+                switch(jsDoc.tag.toLowerCase()) {
                   case 'attr':
                   case 'attribute':
                     const attributeAlreadyExists = classDoc?.attributes?.find(attr => attr.name === jsDoc.name);
@@ -87,10 +87,10 @@ export function classJsDocPlugin() {
                   case 'element':
                     classDoc.tagName = jsDoc?.name || '';
                     break;
-                  case 'customState':
+                  case 'cssstate':
                     let statePropertyDoc = {};
                     statePropertyDoc = handleClassJsDoc(statePropertyDoc, jsDoc);
-                    classDoc.customStates.push(statePropertyDoc);
+                    classDoc.cssStates.push(statePropertyDoc);
                     break;
                   case 'deprecated':
                     classDoc.deprecated = jsDoc?.name ? `${jsDoc.name} ${jsDoc?.description}`.trim() : "true";

--- a/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
+++ b/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
@@ -87,9 +87,7 @@ export function classJsDocPlugin() {
                   case 'element':
                     classDoc.tagName = jsDoc?.name || '';
                     break;
-                  case 'state':
                   case 'customState':
-                    console.log("CUSTOM STATE")
                     let statePropertyDoc = {};
                     statePropertyDoc = handleClassJsDoc(statePropertyDoc, jsDoc);
                     classDoc.customStates.push(statePropertyDoc);

--- a/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
+++ b/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
@@ -35,7 +35,7 @@ export function classJsDocPlugin() {
               if(parsedJsDoc?.tags?.some(tag => tag?.tag === 'typedef')) return;
 
               parsedJsDoc?.tags?.forEach(jsDoc => {
-                switch(jsDoc.tag.toLowerCase()) {
+                switch(jsDoc.tag) {
                   case 'attr':
                   case 'attribute':
                     const attributeAlreadyExists = classDoc?.attributes?.find(attr => attr.name === jsDoc.name);
@@ -87,6 +87,7 @@ export function classJsDocPlugin() {
                   case 'element':
                     classDoc.tagName = jsDoc?.name || '';
                     break;
+                  case 'cssState':
                   case 'cssstate':
                     let statePropertyDoc = {};
                     statePropertyDoc = handleClassJsDoc(statePropertyDoc, jsDoc);

--- a/packages/analyzer/src/features/analyse-phase/creators/createClass.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/createClass.js
@@ -24,7 +24,8 @@ export function createClass(node, moduleDoc, context) {
     slots: [],
     members: [],
     events: [],
-    attributes: []
+    attributes: [],
+    customStates: [],
   };
 
   node?.members?.forEach(member => {
@@ -33,7 +34,7 @@ export function createClass(node, moduleDoc, context) {
      */
     if (isProperty(member)) {
       if (member?.name?.getText() === 'observedAttributes') {
-        /** 
+        /**
          * @example static observedAttributes
          */
         if (ts.isPropertyDeclaration(member)) {
@@ -64,7 +65,7 @@ export function createClass(node, moduleDoc, context) {
 
   /**
    * Second pass through a class's members.
-   * We do this in two passes, because we need to know whether or not a class has any 
+   * We do this in two passes, because we need to know whether or not a class has any
    * attributes, so we handle those first.
    */
   node?.members?.forEach(member => {
@@ -124,7 +125,7 @@ export function createClass(node, moduleDoc, context) {
       /**
        * A class can have a static prop and an instance prop with the same name,
        * both should be output in the CEM
-       * 
+       *
        * If not a static prop, we merge getter and setter pairs here
        */
       if (field?.static) {
@@ -144,7 +145,7 @@ export function createClass(node, moduleDoc, context) {
 
     /**
      * Handle events
-     * 
+     *
      * In order to find `this.dispatchEvent` calls, we have to traverse a method's AST
      */
     if (ts.isMethodDeclaration(member)) {
@@ -210,7 +211,7 @@ export function getDefaultValuesFromConstructorVisitor(source, classTemplate, co
   function visitNode(node) {
     switch (node.kind) {
       case ts.SyntaxKind.Constructor:
-        /** 
+        /**
          * For every member that was added in the classDoc, we want to add a default value if we can
          * To do this, we visit a class's constructor, and loop through the statements
          */

--- a/packages/analyzer/src/features/analyse-phase/creators/createClass.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/createClass.js
@@ -25,7 +25,7 @@ export function createClass(node, moduleDoc, context) {
     members: [],
     events: [],
     attributes: [],
-    customStates: [],
+    cssStates: [],
   };
 
   node?.members?.forEach(member => {

--- a/packages/analyzer/src/features/link-phase/cleanup-classes.js
+++ b/packages/analyzer/src/features/link-phase/cleanup-classes.js
@@ -13,7 +13,7 @@ export function cleanupClassesPlugin() {
       const classes = moduleDoc?.declarations?.filter(declaration => declaration.kind === 'class' || declaration.kind === 'mixin');
 
       classes?.forEach(klass => {
-        ['cssProperties', 'cssParts', 'slots', 'members', 'attributes', 'events', 'customStates'].forEach(field => {
+        ['cssProperties', 'cssParts', 'slots', 'members', 'attributes', 'events', 'cssStates'].forEach(field => {
           if(!has(klass[field])) {
             delete klass[field];
           }

--- a/packages/analyzer/src/features/link-phase/cleanup-classes.js
+++ b/packages/analyzer/src/features/link-phase/cleanup-classes.js
@@ -2,8 +2,8 @@ import { has } from "../../utils/index.js"
 
 /**
  * CLEANUP-CLASSES
- * 
- * Removes empty arrays from classes; e.g. if a class doesn't have any `members`, 
+ *
+ * Removes empty arrays from classes; e.g. if a class doesn't have any `members`,
  * then we remove it from the class doc
  */
 export function cleanupClassesPlugin() {
@@ -13,7 +13,7 @@ export function cleanupClassesPlugin() {
       const classes = moduleDoc?.declarations?.filter(declaration => declaration.kind === 'class' || declaration.kind === 'mixin');
 
       classes?.forEach(klass => {
-        ['cssProperties', 'cssParts', 'slots', 'members', 'attributes', 'events'].forEach(field => {
+        ['cssProperties', 'cssParts', 'slots', 'members', 'attributes', 'events', 'customStates'].forEach(field => {
           if(!has(klass[field])) {
             delete klass[field];
           }

--- a/packages/analyzer/src/features/post-processing/apply-inheritance.js
+++ b/packages/analyzer/src/features/post-processing/apply-inheritance.js
@@ -28,7 +28,7 @@ export function applyInheritancePlugin() {
             return;
           }
 
-          ['slots', 'cssParts', 'cssProperties', 'attributes', 'members', 'events'].forEach(type => {
+          ['slots', 'cssParts', 'cssProperties', 'attributes', 'members', 'events', 'customStates'].forEach(type => {
             klass?.[type]?.forEach(currItem => {
               const containingModulePath = getModuleForClassLike(allManifests, klass.name);
               const containingModule = getModuleFromManifests(allManifests, containingModulePath);

--- a/packages/analyzer/src/features/post-processing/apply-inheritance.js
+++ b/packages/analyzer/src/features/post-processing/apply-inheritance.js
@@ -28,7 +28,7 @@ export function applyInheritancePlugin() {
             return;
           }
 
-          ['slots', 'cssParts', 'cssProperties', 'attributes', 'members', 'events', 'customStates'].forEach(type => {
+          ['slots', 'cssParts', 'cssProperties', 'attributes', 'members', 'events', 'cssStates'].forEach(type => {
             klass?.[type]?.forEach(currItem => {
               const containingModulePath = getModuleForClassLike(allManifests, klass.name);
               const containingModule = getModuleFromManifests(allManifests, containingModulePath);


### PR DESCRIPTION
Fixes #246 

I went with `@customState` instead of `@state` to disambiguate from `@state()` decorator from Lit.