### PR TITLE
web: don't fail when `name.text` is undefined

### DIFF
--- a/packages/analyzer/src/features/analyse-phase/creators/handlers.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/handlers.js
@@ -34,7 +34,7 @@ export function handleModifiers(doc, node) {
     }
   });
 
-  if (node.name?.text.startsWith('#')) {
+  if (node.name?.text?.startsWith('#')) {
     doc.privacy = 'private';
   }
 


### PR DESCRIPTION
The check here is that `node.name` can be undefined; we then know that the node is private.  But `node.name.text` can be undefined, and that should also not throw an exception at this check. I've added a small check to ensure this won't throw.