### PR TITLE
feat: `--stencil` now outputs `default` & `description` for attributes

### DIFF
--- a/packages/analyzer/fixtures/08-plugin-stencil/01-basic/output.json
+++ b/packages/analyzer/fixtures/08-plugin-stencil/01-basic/output.json
@@ -78,7 +78,8 @@
             },
             {
               "name": "message",
-              "fieldName": "message"
+              "fieldName": "message",
+              "default": "'Hello'"
             }
           ],
           "tagName": "todo-list",

--- a/packages/analyzer/src/features/framework-plugins/stencil/stencil.js
+++ b/packages/analyzer/src/features/framework-plugins/stencil/stencil.js
@@ -74,15 +74,15 @@ export function stencilPlugin() {
               if(!currClass.attributes) currClass.attributes = [];
               const hasType = !!property?.type?.getText?.();
 
-              currClass.attributes.push({
-                name: attrName,
-                fieldName,
-                ...(hasType ? {
-                  type: { text: property?.type?.getText?.() }
-                } : {}),
-                default: member?.default,
-                description: member?.description
-              })
+                currClass.attributes.push({
+                  name: attrName,
+                  fieldName,
+                  ...(member?.default ? { default: member.default } : {}),
+                  ...(member?.description ? { description: member.description } : {}),
+                  ...(hasType ? {
+                    type: { text: property?.type?.getText?.() }
+                  } : {})
+                })
             });
 
           break;

--- a/packages/analyzer/src/features/framework-plugins/stencil/stencil.js
+++ b/packages/analyzer/src/features/framework-plugins/stencil/stencil.js
@@ -14,7 +14,7 @@ export function stencilPlugin() {
           /**
            * Add tagName to classDoc, extracted from `@Component({tag: 'foo-bar'})` decorator
            * Add custom-element-definition to exports
-           */ 
+           */
           const componentDecorator = node?.modifiers?.find(decorator('Component'))?.expression;
 
           const tagName = componentDecorator?.arguments?.[0]?.properties?.find(prop => {
@@ -35,9 +35,9 @@ export function stencilPlugin() {
             });
           }
 
-          /** 
+          /**
            * Collect fields with `@Event()` decorator so we can process them in `moduleLinkPhase`
-           */ 
+           */
           const eventFields = node?.members
             ?.filter(member => member?.modifiers?.find(decorator('Event')))
             ?.map(member => {
@@ -63,7 +63,7 @@ export function stencilPlugin() {
               const fieldName = property?.name?.text;
               const attrNameFromDecorator = property?.modifiers?.[0]?.expression?.arguments?.[0]?.properties?.find(prop => prop?.name?.getText() === 'attribute')?.initializer?.text;
               const attrName = attrNameFromDecorator || toKebabCase(property?.name?.text);
-              
+
               const reflects = property?.modifiers?.[0]?.expression?.arguments?.[0]?.properties?.find(prop => prop?.name?.getText() === 'reflects')?.initializer?.getText?.() === 'true';
               const member = currClass?.members?.find(mem => mem?.name === fieldName);
               if(reflects) {
@@ -79,19 +79,21 @@ export function stencilPlugin() {
                 fieldName,
                 ...(hasType ? {
                   type: { text: property?.type?.getText?.() }
-                } : {})
+                } : {}),
+                default: member?.default,
+                description: member?.description
               })
             });
 
           break;
       }
     },
-    
+
     // Runs for each module, after analyzing, all information about your module should now be available
     moduleLinkPhase({moduleDoc}){
       /**
        * Remove lifecycle methods
-       */ 
+       */
       const classes = moduleDoc?.declarations?.filter(declaration => declaration.kind === 'class');
 
       classes?.forEach(klass => {
@@ -102,7 +104,7 @@ export function stencilPlugin() {
       });
 
       /**
-       * Events 
+       * Events
        */
       classes?.forEach(klass => {
         if(!klass?.members) return;


### PR DESCRIPTION
Fixes #285 

The stencil plugin now correctly populates the artificially created attribute for a field with `default` and `description` from the detected member (if present), where it did not before:

| stencil code | output |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/610ff0f8-bee7-4a0d-a16e-c817af434a58) | ![image](https://github.com/user-attachments/assets/55d848bd-90ca-4b76-8b2f-2c2929790242) | 

I investigated using [handleDefaultValue](https://github.com/open-wc/custom-elements-manifest/blob/master/packages/analyzer/src/features/analyse-phase/creators/handlers.js#L282) per https://github.com/open-wc/custom-elements-manifest/issues/285#issuecomment-2521717424, but I don't think that function applies.

This is an artificially created attribute [being injected](https://github.com/open-wc/custom-elements-manifest/blob/94650b64f992c216ff770ac9e398db7c4491c949/packages/analyzer/src/features/framework-plugins/stencil/stencil.js#L77-L83) into the class, and since handleDefaultValue is already ran to obtain the resultant values we see in the member already, we just need to copy values over to our artificial object.

I tested this locally on my custom stencil elements and it all seemed to work as expected. Members which did not have a default value nor description did not create extant fields in the produced attributes:

| (no default, no desc) | (no default, no desc) |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0cfd2bf1-b2f0-4a16-ad52-69480ba44f14) | ![image](https://github.com/user-attachments/assets/b66042ec-a137-433f-a1f4-f6628b1e9cfd) | 

I also cleaned up some errant whitespace.
