### PR TITLE
fix: add default packagejson config for analyzer

### DIFF
--- a/packages/analyzer/src/utils/cli-helpers.js
+++ b/packages/analyzer/src/utils/cli-helpers.js
@@ -56,6 +56,7 @@ export const DEFAULTS = {
   globs: ['**/*.{js,ts,tsx}'],
   dev: false,
   quiet: false,
+  packagejson: true,
   watch: false,
   litelement: false,
   stencil: false,


### PR DESCRIPTION
The documentation [here](https://custom-elements-manifest.open-wc.org/analyzer/config/#cli-options) states that the default configuration for `packagejson` is true but it doesn't seem to come through and has to be added.