### PR TITLE
fix: code tab hover color in light mode (minor a11y issue)

### DIFF
--- a/docs/_assets/theme.css
+++ b/docs/_assets/theme.css
@@ -3,6 +3,7 @@ html {
   --button-one: #2758ff;
   --button-two-hover: #444;
   --button-two: black;
+  --code-button-focus-color: color-mix(in srgb, currentColor 75%, transparent);
   --code-button-focus-background: var(--markdown-syntax-background-color);
   --code-button-background: var(--markdown-table-row-odd-background-color);
   --code-tabs-tabs-background: var(--page-background);


### PR DESCRIPTION
When hovering over a `<code-tabs>` button while in light mode, the hover state flips from the primary text color, which is nearly black (#2c3e50) on a light gray, to white, which isn't visible on the light background. This is due to the failover which is currently being used since `--code-button-focus-color` is currently undefined. Since there's a light/dark theme here and it seems like the inherited text color is already used, I just set the current color to 75% opacity (which was what was already happening, particularly on the dark theme). So, no visible change for dark, just apply the same change for white.

Note: I'm using `color-mix()` here but support for it is very good and growing (~92% which is pretty decent). See: https://caniuse.com/mdn-css_types_color_color-mix. Not to mention it's more of a focus/hover state which won't affect touch devices so much (where the bulk of support is lacking, older Safari versions).

![image](https://github.com/user-attachments/assets/7f30e2a8-2382-43b9-a155-91cf312f737d)

Before/after demo for you:

![2025-01-05_17-23-41](https://github.com/user-attachments/assets/1b6fbcde-f88a-4f68-baf1-d9e9b3bcb1e1)
