### PR TITLE
chore: added repo field to find-dependencies package.json

### DIFF
--- a/packages/find-dependencies/package.json
+++ b/packages/find-dependencies/package.json
@@ -2,6 +2,11 @@
   "name": "@custom-elements-manifest/find-dependencies",
   "version": "0.0.5",
   "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wc/custom-elements-manifest.git",
+    "directory": "packages/find-dependencies"
+  },
   "main": "index.js",
   "scripts": {
     "start": "nodemon dev.js",


### PR DESCRIPTION
Adding missing `repo` field to `packages/find-dependencies/package.json` to improve the scans made with SNYK tools of the `@custom-elements-manifest/find-dependencies` package.