### PR TITLE
Fix: Preserve attribute name when @attr decorator has options without explicit attribute name

### DIFF
--- a/packages/analyzer/fixtures/09-plugin-fast/02-test-boolean-attr/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/09-plugin-fast/02-test-boolean-attr/fixture/custom-elements.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "BooleanTest",
+          "members": [
+            {
+              "kind": "field",
+              "name": "normalAttr"
+            },
+            {
+              "kind": "field",
+              "name": "booleanAttr"
+            },
+            {
+              "kind": "field",
+              "name": "explicitName"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "normalAttr",
+              "fieldName": "normalAttr"
+            },
+            {
+              "name": "booleanAttr",
+              "fieldName": "booleanAttr"
+            },
+            {
+              "name": "customName",
+              "fieldName": "explicitName"
+            }
+          ],
+          "superclass": {
+            "name": "FASTElement",
+            "package": "@microsoft/fast-element"
+          },
+          "tagName": "boolean-test",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "BooleanTest",
+          "declaration": {
+            "name": "BooleanTest",
+            "module": "my-element.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "boolean-test",
+          "declaration": {
+            "name": "BooleanTest",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/09-plugin-fast/02-test-boolean-attr/package/my-element.js
+++ b/packages/analyzer/fixtures/09-plugin-fast/02-test-boolean-attr/package/my-element.js
@@ -1,0 +1,13 @@
+import { FASTElement, customElement, attr } from '@microsoft/fast-element';
+
+@customElement('boolean-test')
+export class BooleanTest extends FASTElement {
+  // Should have name: "normalAttr"
+  @attr normalAttr;
+  
+  // Should have name: "booleanAttr" 
+  @attr({ mode: "boolean" }) booleanAttr;
+  
+  // Should have name: "customName"
+  @attr({ attribute: "customName", mode: "boolean" }) explicitName;
+}

--- a/packages/analyzer/src/features/framework-plugins/decorators/attr.js
+++ b/packages/analyzer/src/features/framework-plugins/decorators/attr.js
@@ -36,7 +36,9 @@ export function attrDecoratorPlugin(converter) {
               const optionsObject = getOptionsObject(hasAttrDecorator);
               if(optionsObject) {
                 const name = optionsObject?.properties?.find(prop => prop.name.getText() === 'attribute')?.initializer?.text;
-                attribute.name = name;
+                if(name) {
+                  attribute.name = name;
+                }
               }
 
               if (converter) {


### PR DESCRIPTION
## Problem
When using `@attr({ mode: "boolean" })`, the analyzer was filtering out the "name" field from the attribute manifest output. The attribute would appear without a name field, unlike `@attr` (which uses field name) or `@attr({ attribute: "custom-name" })` (which uses explicit name).

## Root Cause
In `attr.js`, when an options object existed but had no `attribute` property, the code was setting `attribute.name = undefined`, overwriting the correctly set field name.

## Solution
Added a null check to only set `attribute.name` when an explicit name is actually provided:
```javascript
if(name) {
  attribute.name = name;
}
```

Closes: #313 

Test Cases
✅ @attr normalAttr → [name: "normalAttr"]
✅ @attr({ attribute: "custom-name" }) → [name: "custom-name"] (explicit name)
✅ @attr({ mode: "boolean" }) booleanAttr → [name: "booleanAttr"] (preserves field name)