### PR TITLE
add functionality to programmatically generate a CEM

### DIFF
--- a/packages/analyzer/README.md
+++ b/packages/analyzer/README.md
@@ -47,18 +47,6 @@ const manifest = await generateManifest({
 console.log(manifest);
 ```
 
-Or load from a config file:
-
-```javascript
-import { generateManifest } from '@custom-elements-manifest/analyzer';
-
-// Using a config file path
-const manifest = await generateManifest('./custom-elements-manifest.config.js', {
-  cwd: process.cwd(),
-  write: true  // Write to disk (default: true)
-});
-```
-
 Generate without writing to disk:
 
 ```javascript
@@ -101,12 +89,6 @@ export default {
     })
   ]
 };
-```
-
-You can also pass a config file path:
-
-```javascript
-rollupCemAnalyzerPlugin('./custom-elements-manifest.config.js')
 ```
 
 The plugin is compatible with Rollup and Rollup-based tools like Vite and Web Dev Server. It automatically generates the manifest at the start of each build.

--- a/packages/analyzer/README.md
+++ b/packages/analyzer/README.md
@@ -16,6 +16,8 @@ npm i -D @custom-elements-manifest/analyzer
 
 ## Usage
 
+### CLI
+
 ```bash
 custom-elements-manifest analyze
 ```
@@ -25,6 +27,89 @@ or
 ```bash
 cem analyze
 ```
+
+### Programmatic API
+
+You can also use the analyzer programmatically in your Node.js scripts:
+
+```javascript
+import { generateManifest } from '@custom-elements-manifest/analyzer';
+
+// Using a configuration object
+const manifest = await generateManifest({
+  globs: ['src/**/*.js'],
+  exclude: ['**/*.test.js'],
+  outdir: './dist',
+  litelement: true,
+  dependencies: true
+});
+
+console.log(manifest);
+```
+
+Or load from a config file:
+
+```javascript
+import { generateManifest } from '@custom-elements-manifest/analyzer';
+
+// Using a config file path
+const manifest = await generateManifest('./custom-elements-manifest.config.js', {
+  cwd: process.cwd(),
+  write: true  // Write to disk (default: true)
+});
+```
+
+Generate without writing to disk:
+
+```javascript
+import { generateManifest } from '@custom-elements-manifest/analyzer';
+
+// Generate manifest without writing to disk
+const manifest = await generateManifest({
+  globs: ['src/**/*.js'],
+  outdir: './dist'
+}, {
+  write: false  // Don't write to disk
+});
+
+// Process manifest in memory
+console.log(JSON.stringify(manifest, null, 2));
+```
+
+### Build Tool Plugins
+
+#### Rollup Plugin
+
+Integrate manifest generation into your Rollup build process:
+
+```javascript
+// rollup.config.js
+import { rollupCemAnalyzerPlugin } from '@custom-elements-manifest/analyzer';
+
+export default {
+  input: 'src/index.js',
+  output: {
+    dir: 'dist',
+    format: 'es'
+  },
+  plugins: [
+    rollupCemAnalyzerPlugin({
+      globs: ['src/**/*.js'],
+      exclude: ['**/*.test.js'],
+      outdir: './dist',
+      litelement: true
+    })
+  ]
+};
+```
+
+You can also pass a config file path:
+
+```javascript
+rollupCemAnalyzerPlugin('./custom-elements-manifest.config.js')
+```
+
+The plugin is compatible with Rollup and Rollup-based tools like Vite and Web Dev Server. It automatically generates the manifest at the start of each build.
 
 ## Options
 

--- a/packages/analyzer/fixtures/01-class/-default/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/custom-dir/custom-elements.json
+++ b/packages/analyzer/fixtures/01-class/-default/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/custom-dir/custom-elements.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "bar.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "foo",
+          "type": {
+            "text": "number"
+          },
+          "default": "1"
+        },
+        {
+          "kind": "variable",
+          "name": "bar",
+          "type": {
+            "text": "object"
+          },
+          "default": "{ foo, }"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "bar",
+          "declaration": {
+            "name": "bar",
+            "module": "bar.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/01-class/-default/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/custom-elements.json
+++ b/packages/analyzer/fixtures/01-class/-default/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/custom-elements.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "bar.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "foo",
+          "type": {
+            "text": "number"
+          },
+          "default": "1"
+        },
+        {
+          "kind": "variable",
+          "name": "bar",
+          "type": {
+            "text": "object"
+          },
+          "default": "{ foo, }"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "bar",
+          "declaration": {
+            "name": "bar",
+            "module": "bar.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/01-class/-default/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/new/nested/dir/custom-elements.json
+++ b/packages/analyzer/fixtures/01-class/-default/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/new/nested/dir/custom-elements.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "bar.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "foo",
+          "type": {
+            "text": "number"
+          },
+          "default": "1"
+        },
+        {
+          "kind": "variable",
+          "name": "bar",
+          "type": {
+            "text": "object"
+          },
+          "default": "{ foo, }"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "bar",
+          "declaration": {
+            "name": "bar",
+            "module": "bar.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/01-class/01-fields/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/custom-dir/custom-elements.json
+++ b/packages/analyzer/fixtures/01-class/01-fields/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/custom-dir/custom-elements.json
@@ -1,0 +1,324 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyEl",
+          "members": [
+            {
+              "kind": "field",
+              "name": "prop1",
+              "type": {
+                "text": "string"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "prop2",
+              "type": {
+                "text": "string"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop3",
+              "type": {
+                "text": "SomeType"
+              },
+              "description": "prop3 description",
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop4",
+              "type": {
+                "text": "Some.Type"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop5",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "setter",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "getter2",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "getter2",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "alsoAttr",
+              "description": "This is also an attribute",
+              "reflects": true,
+              "type": {
+                "text": "string"
+              },
+              "attribute": "also-attr"
+            },
+            {
+              "kind": "field",
+              "name": "prop6",
+              "privacy": "public"
+            },
+            {
+              "kind": "field",
+              "name": "prop7",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "prop8",
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "prop9",
+              "privacy": "public"
+            },
+            {
+              "kind": "field",
+              "name": "prop10",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "prop11",
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "prop11",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "prop12",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "bool",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "str",
+              "type": {
+                "text": "string"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "num",
+              "type": {
+                "text": "number"
+              },
+              "default": "1"
+            },
+            {
+              "kind": "field",
+              "name": "arr",
+              "type": {
+                "text": "array"
+              },
+              "default": "[{a: \"a\", b: 'b', c: `c`}, 1, \"a\", 'b', `c`]"
+            },
+            {
+              "kind": "field",
+              "name": "obj",
+              "type": {
+                "text": "object"
+              },
+              "default": "{a: \"a\", b: 'b', c: `c`}"
+            },
+            {
+              "kind": "field",
+              "name": "asVariable",
+              "default": "'bar'",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asVariableAssignedInConstructor",
+              "default": "'foo'",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asVariableThirdParty",
+              "default": "buu"
+            },
+            {
+              "kind": "field",
+              "name": "nu",
+              "type": {
+                "text": "null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "field",
+              "name": "asConst",
+              "default": "'const'",
+              "type": {
+                "text": "'const'"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asConstRef",
+              "default": "{foo:'bar'}",
+              "type": {
+                "text": "{foo:'bar'}"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "strOverwritten",
+              "type": {
+                "text": "Foo"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "#prop13",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "optional",
+              "type": {
+                "text": "string | undefined"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary1",
+              "type": {
+                "text": "number"
+              },
+              "default": "+1"
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary2",
+              "type": {
+                "text": "number"
+              },
+              "default": "-1"
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary3",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "!1"
+            },
+            {
+              "kind": "field",
+              "name": "arrowfn"
+            },
+            {
+              "kind": "field",
+              "name": "#truePrivateField",
+              "privacy": "private",
+              "type": {
+                "text": "number"
+              },
+              "default": "1"
+            },
+            {
+              "kind": "method",
+              "name": "#truePrivateMethod",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop1",
+              "type": {
+                "text": "string"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop2",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop3",
+              "type": {
+                "text": "number"
+              },
+              "default": "123"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "also-attr",
+              "description": "This is also an attribute",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "alsoAttr"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-el",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-el",
+          "declaration": {
+            "name": "MyEl",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/01-class/01-fields/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/custom-elements.json
+++ b/packages/analyzer/fixtures/01-class/01-fields/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/custom-elements.json
@@ -1,0 +1,324 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyEl",
+          "members": [
+            {
+              "kind": "field",
+              "name": "prop1",
+              "type": {
+                "text": "string"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "prop2",
+              "type": {
+                "text": "string"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop3",
+              "type": {
+                "text": "SomeType"
+              },
+              "description": "prop3 description",
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop4",
+              "type": {
+                "text": "Some.Type"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop5",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "setter",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "getter2",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "getter2",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "alsoAttr",
+              "description": "This is also an attribute",
+              "reflects": true,
+              "type": {
+                "text": "string"
+              },
+              "attribute": "also-attr"
+            },
+            {
+              "kind": "field",
+              "name": "prop6",
+              "privacy": "public"
+            },
+            {
+              "kind": "field",
+              "name": "prop7",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "prop8",
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "prop9",
+              "privacy": "public"
+            },
+            {
+              "kind": "field",
+              "name": "prop10",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "prop11",
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "prop11",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "prop12",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "bool",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "str",
+              "type": {
+                "text": "string"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "num",
+              "type": {
+                "text": "number"
+              },
+              "default": "1"
+            },
+            {
+              "kind": "field",
+              "name": "arr",
+              "type": {
+                "text": "array"
+              },
+              "default": "[{a: \"a\", b: 'b', c: `c`}, 1, \"a\", 'b', `c`]"
+            },
+            {
+              "kind": "field",
+              "name": "obj",
+              "type": {
+                "text": "object"
+              },
+              "default": "{a: \"a\", b: 'b', c: `c`}"
+            },
+            {
+              "kind": "field",
+              "name": "asVariable",
+              "default": "'bar'",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asVariableAssignedInConstructor",
+              "default": "'foo'",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asVariableThirdParty",
+              "default": "buu"
+            },
+            {
+              "kind": "field",
+              "name": "nu",
+              "type": {
+                "text": "null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "field",
+              "name": "asConst",
+              "default": "'const'",
+              "type": {
+                "text": "'const'"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asConstRef",
+              "default": "{foo:'bar'}",
+              "type": {
+                "text": "{foo:'bar'}"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "strOverwritten",
+              "type": {
+                "text": "Foo"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "#prop13",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "optional",
+              "type": {
+                "text": "string | undefined"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary1",
+              "type": {
+                "text": "number"
+              },
+              "default": "+1"
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary2",
+              "type": {
+                "text": "number"
+              },
+              "default": "-1"
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary3",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "!1"
+            },
+            {
+              "kind": "field",
+              "name": "arrowfn"
+            },
+            {
+              "kind": "field",
+              "name": "#truePrivateField",
+              "privacy": "private",
+              "type": {
+                "text": "number"
+              },
+              "default": "1"
+            },
+            {
+              "kind": "method",
+              "name": "#truePrivateMethod",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop1",
+              "type": {
+                "text": "string"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop2",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop3",
+              "type": {
+                "text": "number"
+              },
+              "default": "123"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "also-attr",
+              "description": "This is also an attribute",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "alsoAttr"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-el",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-el",
+          "declaration": {
+            "name": "MyEl",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/01-class/01-fields/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/new/nested/dir/custom-elements.json
+++ b/packages/analyzer/fixtures/01-class/01-fields/package/home/parallels/Documents/Projects/custom-elements-manifest/packages/analyzer/test/test-output/new/nested/dir/custom-elements.json
@@ -1,0 +1,324 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyEl",
+          "members": [
+            {
+              "kind": "field",
+              "name": "prop1",
+              "type": {
+                "text": "string"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "prop2",
+              "type": {
+                "text": "string"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop3",
+              "type": {
+                "text": "SomeType"
+              },
+              "description": "prop3 description",
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop4",
+              "type": {
+                "text": "Some.Type"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "prop5",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "setter",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "getter2",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "getter2",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "alsoAttr",
+              "description": "This is also an attribute",
+              "reflects": true,
+              "type": {
+                "text": "string"
+              },
+              "attribute": "also-attr"
+            },
+            {
+              "kind": "field",
+              "name": "prop6",
+              "privacy": "public"
+            },
+            {
+              "kind": "field",
+              "name": "prop7",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "prop8",
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "prop9",
+              "privacy": "public"
+            },
+            {
+              "kind": "field",
+              "name": "prop10",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "prop11",
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "prop11",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "prop12",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "bool",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "str",
+              "type": {
+                "text": "string"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "num",
+              "type": {
+                "text": "number"
+              },
+              "default": "1"
+            },
+            {
+              "kind": "field",
+              "name": "arr",
+              "type": {
+                "text": "array"
+              },
+              "default": "[{a: \"a\", b: 'b', c: `c`}, 1, \"a\", 'b', `c`]"
+            },
+            {
+              "kind": "field",
+              "name": "obj",
+              "type": {
+                "text": "object"
+              },
+              "default": "{a: \"a\", b: 'b', c: `c`}"
+            },
+            {
+              "kind": "field",
+              "name": "asVariable",
+              "default": "'bar'",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asVariableAssignedInConstructor",
+              "default": "'foo'",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asVariableThirdParty",
+              "default": "buu"
+            },
+            {
+              "kind": "field",
+              "name": "nu",
+              "type": {
+                "text": "null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "field",
+              "name": "asConst",
+              "default": "'const'",
+              "type": {
+                "text": "'const'"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "asConstRef",
+              "default": "{foo:'bar'}",
+              "type": {
+                "text": "{foo:'bar'}"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "strOverwritten",
+              "type": {
+                "text": "Foo"
+              },
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "#prop13",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "optional",
+              "type": {
+                "text": "string | undefined"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary1",
+              "type": {
+                "text": "number"
+              },
+              "default": "+1"
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary2",
+              "type": {
+                "text": "number"
+              },
+              "default": "-1"
+            },
+            {
+              "kind": "field",
+              "name": "prefixUnary3",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "!1"
+            },
+            {
+              "kind": "field",
+              "name": "arrowfn"
+            },
+            {
+              "kind": "field",
+              "name": "#truePrivateField",
+              "privacy": "private",
+              "type": {
+                "text": "number"
+              },
+              "default": "1"
+            },
+            {
+              "kind": "method",
+              "name": "#truePrivateMethod",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop1",
+              "type": {
+                "text": "string"
+              },
+              "default": "'default'"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop2",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "commaprop3",
+              "type": {
+                "text": "number"
+              },
+              "default": "123"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "also-attr",
+              "description": "This is also an attribute",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "alsoAttr"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-el",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-el",
+          "declaration": {
+            "name": "MyEl",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/index.d.ts
+++ b/packages/analyzer/index.d.ts
@@ -180,9 +180,9 @@ export interface Config {
 }
 
 /**
- * Generate a custom elements manifest from a configuration object or config file path.
+ * Generate a custom elements manifest from a configuration object.
  * 
- * @param config - Configuration object or path to a config file
+ * @param config - Configuration object
  * @param options - Additional options
  * @param options.cwd - Current working directory (defaults to process.cwd())
  * @param options.write - Whether to write the manifest to disk (defaults to true)
@@ -196,15 +196,10 @@ export interface Config {
  *   outdir: './dist',
  *   litelement: true
  * });
- * 
- * // Using a config file path
- * const manifest = await generateManifest('./custom-elements-manifest.config.js', {
- *   cwd: process.cwd()
- * });
  * ```
  */
 export function generateManifest(
-  config: Config | string,
+  config?: Config,
   options?: {
     cwd?: string;
     write?: boolean;

--- a/packages/analyzer/index.d.ts
+++ b/packages/analyzer/index.d.ts
@@ -178,3 +178,35 @@ export interface Config {
   /** Resolution options when using `dependencies: true` */
   resolutionOptions?: NapiResolveOptions;
 }
+
+/**
+ * Generate a custom elements manifest from a configuration object or config file path.
+ * 
+ * @param config - Configuration object or path to a config file
+ * @param options - Additional options
+ * @param options.cwd - Current working directory (defaults to process.cwd())
+ * @param options.write - Whether to write the manifest to disk (defaults to true)
+ * @returns The generated custom elements manifest
+ * 
+ * @example
+ * ```typescript
+ * // Using a config object
+ * const manifest = await generateManifest({
+ *   globs: ['src/**\/*.js'],
+ *   outdir: './dist',
+ *   litelement: true
+ * });
+ * 
+ * // Using a config file path
+ * const manifest = await generateManifest('./custom-elements-manifest.config.js', {
+ *   cwd: process.cwd()
+ * });
+ * ```
+ */
+export function generateManifest(
+  config: Config | string,
+  options?: {
+    cwd?: string;
+    write?: boolean;
+  }
+): Promise<Package>;

--- a/packages/analyzer/index.js
+++ b/packages/analyzer/index.js
@@ -1,3 +1,5 @@
 export { create } from './src/create.js';
+export { generateManifest } from './manifest-generator.js';
+export { rollupCemAnalyzerPlugin } from './src/build-tool-plugins/rollup.js';
 // Export ts to avoid version mismatch when using the create() method programmatically 
 export { default as ts } from 'typescript';

--- a/packages/analyzer/manifest-generator.js
+++ b/packages/analyzer/manifest-generator.js
@@ -1,0 +1,111 @@
+import ts from "typescript";
+import path from "path";
+import globby from "globby";
+import fs from "fs";
+
+import { create } from "./src/create.js";
+import {
+  getUserConfig,
+  addFrameworkPlugins,
+  mergeGlobsAndExcludes,
+  DEFAULTS,
+} from "./src/utils/cli-helpers.js";
+import { findExternalManifests } from "./src/utils/find-external-manifests.js";
+import { mergeResolutionOptions } from "./src/utils/resolver-config.js";
+
+/**
+ * This module provides functionality to generate a manifest file
+ * based on the provided configuration.
+ * @param {import('./index').Config | string} config - Configuration object or path to config file
+ * @param {Object} options - Additional options
+ * @param {string} [options.cwd=process.cwd()] - Current working directory
+ * @param {boolean} [options.write=true] - Whether to write the manifest to disk
+ * @returns {Promise<import('custom-elements-manifest/schema').Package>} The generated custom elements manifest
+ */
+export async function generateManifest(config, options = {}) {
+  const { cwd = process.cwd(), write = true } = options;
+  
+  // Load user config if a path was provided
+  let userConfig = {};
+  if (typeof config === 'string') {
+    userConfig = await getUserConfig(config, cwd);
+  } else {
+    userConfig = config || {};
+  }
+
+  // Merge with defaults
+  const mergedOptions = { ...DEFAULTS, ...userConfig };
+  const merged = mergeGlobsAndExcludes(DEFAULTS, userConfig, {});
+
+  // Merge resolution options with priority: user config > defaults
+  const resolutionOptions = mergeResolutionOptions(
+    userConfig?.resolutionOptions
+  );
+
+  // Resolve globs
+  const globs = await globby(merged, { cwd });
+
+  // Create TypeScript source files from globs
+  const modules = userConfig?.overrideModuleCreation
+    ? userConfig.overrideModuleCreation({ ts, globs })
+    : globs.map((glob) => {
+        const fullPath = path.resolve(cwd, glob);
+        const source = fs.readFileSync(fullPath).toString();
+        return ts.createSourceFile(
+          glob,
+          source,
+          ts.ScriptTarget.ES2015,
+          true
+        );
+      });
+
+  // Find third-party custom elements manifests if dependencies option is enabled
+  let thirdPartyCEMs = [];
+  if (mergedOptions?.dependencies) {
+    try {
+      const fullPathGlobs = globs.map((glob) => path.resolve(cwd, glob));
+      thirdPartyCEMs = await findExternalManifests(fullPathGlobs, {
+        basePath: cwd,
+        resolutionOptions,
+      });
+    } catch (e) {
+      if (mergedOptions.dev) {
+        console.log(`Failed to add third party CEMs. \n\n${e.stack}`);
+      }
+    }
+  }
+
+  // Add framework plugins
+  let plugins = await addFrameworkPlugins(mergedOptions);
+  plugins = [...plugins, ...(userConfig?.plugins || [])];
+
+  // Create context
+  const context = { dev: mergedOptions.dev, thirdPartyCEMs };
+
+  // Generate the manifest
+  const customElementsManifest = create({ modules, plugins, context });
+
+  if (mergedOptions.dev) {
+    console.log(JSON.stringify(customElementsManifest, null, 2));
+  }
+
+  // Write manifest to disk if requested
+  if (write) {
+    const outdir = path.join(cwd, mergedOptions.outdir);
+    if (!fs.existsSync(outdir)) {
+      fs.mkdirSync(outdir, { recursive: true });
+    }
+    fs.writeFileSync(
+      path.join(outdir, "custom-elements.json"),
+      `${JSON.stringify(customElementsManifest, null, 2)}\n`
+    );
+
+    if (!mergedOptions.quiet) {
+      console.log(
+        `@custom-elements-manifest/analyzer: Created custom-elements.json`
+      );
+    }
+  }
+
+  return customElementsManifest;
+}

--- a/packages/analyzer/manifest-generator.js
+++ b/packages/analyzer/manifest-generator.js
@@ -5,7 +5,6 @@ import fs from "fs";
 
 import { create } from "./src/create.js";
 import {
-  getUserConfig,
   addFrameworkPlugins,
   mergeGlobsAndExcludes,
   DEFAULTS,
@@ -16,22 +15,16 @@ import { mergeResolutionOptions } from "./src/utils/resolver-config.js";
 /**
  * This module provides functionality to generate a manifest file
  * based on the provided configuration.
- * @param {import('./index').Config | string} config - Configuration object or path to config file
+ * @param {import('./index').Config} config - Configuration object
  * @param {Object} options - Additional options
  * @param {string} [options.cwd=process.cwd()] - Current working directory
  * @param {boolean} [options.write=true] - Whether to write the manifest to disk
  * @returns {Promise<import('custom-elements-manifest/schema').Package>} The generated custom elements manifest
  */
-export async function generateManifest(config, options = {}) {
+export async function generateManifest(config = {}, options = {}) {
   const { cwd = process.cwd(), write = true } = options;
   
-  // Load user config if a path was provided
-  let userConfig = {};
-  if (typeof config === 'string') {
-    userConfig = await getUserConfig(config, cwd);
-  } else {
-    userConfig = config || {};
-  }
+  const userConfig = config || {};
 
   // Merge with defaults
   const mergedOptions = { ...DEFAULTS, ...userConfig };

--- a/packages/analyzer/src/build-tool-plugins/rollup.js
+++ b/packages/analyzer/src/build-tool-plugins/rollup.js
@@ -3,7 +3,7 @@ import { generateManifest } from '../../manifest-generator.js';
 /**
  * This function creates a Rollup plugin that generates a custom elements manifest during the build process.
  * This plugin is compatible with popular Rollup-based build tools like Rollup, Vite, and Web Dev Server.
- * @param {import('./index').Config | string} config - Configuration object or path to config file
+ * @param {import('./index').Config} config - Configuration object
  * @returns {Object} Rollup plugin object
  */
 export function rollupCemAnalyzerPlugin(config = {}) {

--- a/packages/analyzer/src/build-tool-plugins/rollup.js
+++ b/packages/analyzer/src/build-tool-plugins/rollup.js
@@ -1,0 +1,16 @@
+import { generateManifest } from '../../manifest-generator.js';
+
+/**
+ * This function creates a Rollup plugin that generates a custom elements manifest during the build process.
+ * This plugin is compatible with popular Rollup-based build tools like Rollup, Vite, and Web Dev Server.
+ * @param {import('./index').Config | string} config - Configuration object or path to config file
+ * @returns {Object} Rollup plugin object
+ */
+export function rollupCemAnalyzerPlugin(config = {}) {
+  return {
+    name: 'rollup-cem-analyzer-plugin',
+    async buildStart() {
+      await generateManifest(config, { cwd: process.cwd(), write: true });
+    },
+  };
+}

--- a/packages/analyzer/src/build-tool-plugins/vite.js
+++ b/packages/analyzer/src/build-tool-plugins/vite.js
@@ -1,0 +1,16 @@
+import { generateManifest } from '../../manifest-generator.js';
+
+/**
+ * This function creates a Vite plugin that generates a custom elements manifest
+ * during the build process.
+ * @param {import('./index').Config} config - Configuration object
+ * @returns {Object} Vite plugin object
+ */
+export function viteCemAnalyzerPlugin(config = {}) {
+  return {
+    name: 'vite-cem-analyzer-plugin',
+    async buildStart() {
+      await generateManifest(config, { cwd: process.cwd(), write: true });
+    },
+  };
+}

--- a/packages/analyzer/test/manifest-generator.test.js
+++ b/packages/analyzer/test/manifest-generator.test.js
@@ -150,38 +150,6 @@ describe('generateManifest', ({ it, afterEach }) => {
     });
   });
 
-  describe('with config file path', ({ it }) => {
-    it('should load config from file path', async () => {
-      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
-      
-      // Create a temporary config file
-      const configPath = path.join(packagePath, 'custom-elements-manifest.config.js');
-      
-      const configContent = `export default {
-  globs: ['**/*.js'],
-  outdir: '.',
-  quiet: true,
-};`;
-      
-      fs.writeFileSync(configPath, configContent);
-
-      try {
-        const manifest = await generateManifest(configPath, {
-          cwd: packagePath,
-          write: false
-        });
-
-        assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
-        assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
-      } finally {
-        // Clean up the temporary config file
-        if (fs.existsSync(configPath)) {
-          fs.unlinkSync(configPath);
-        }
-      }
-    });
-  });
-
   describe('framework plugins', ({ it }) => {
     it('should support litelement option', async () => {
       const packagePath = path.join(fixturesDir, '07-plugin-lit/package');

--- a/packages/analyzer/test/manifest-generator.test.js
+++ b/packages/analyzer/test/manifest-generator.test.js
@@ -1,0 +1,413 @@
+import { describe } from '@asdgf/cli';
+import assert from 'assert';
+import path from 'path';
+import fs from 'fs';
+import { generateManifest } from '../manifest-generator.js';
+
+const fixturesDir = path.join(process.cwd(), 'fixtures');
+const testOutputDir = path.join(process.cwd(), 'test', 'test-output');
+
+// Ensure cleanup happens when the process exits
+process.on('exit', () => {
+  if (fs.existsSync(testOutputDir)) {
+    fs.rmSync(testOutputDir, { recursive: true, force: true });
+  }
+});
+
+describe('generateManifest', ({ it, afterEach }) => {
+  afterEach(() => {
+    // Clean up test output directory after each test
+    if (fs.existsSync(testOutputDir)) {
+      fs.rmSync(testOutputDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('with config object', ({ it }) => {
+    it('should generate manifest from config object', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+      const fixturePath = path.join(fixturesDir, '01-class/01-fields/fixture/custom-elements.json');
+      const expectedManifest = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
+
+      const manifest = await generateManifest({
+        globs: ['**/*.js'],
+        dev: false,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      // Compare without readme field as it might be empty
+      delete manifest.readme;
+      delete expectedManifest.readme;
+
+      assert.deepEqual(manifest, expectedManifest);
+    });
+
+    it('should write manifest to disk when write option is true', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+      const relativeOutdir = path.relative(packagePath, testOutputDir);
+
+      await generateManifest({
+        globs: ['**/*.js'],
+        outdir: relativeOutdir,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: true
+      });
+
+      const manifestPath = path.join(testOutputDir, 'custom-elements.json');
+      assert.ok(fs.existsSync(manifestPath), 'Manifest file should exist');
+
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+      assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+    });
+
+    it('should not write manifest to disk when write option is false', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+      const noWriteDir = path.join(testOutputDir, 'no-write-test');
+      const relativeOutdir = path.relative(packagePath, noWriteDir);
+
+      await generateManifest({
+        globs: ['**/*.js'],
+        outdir: relativeOutdir,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      const manifestPath = path.join(noWriteDir, 'custom-elements.json');
+      assert.ok(!fs.existsSync(manifestPath), 'Manifest file should not exist');
+    });
+
+    it('should handle exclude patterns', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+
+      const manifestWithoutExclude = await generateManifest({
+        globs: ['**/*.js'],
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      const manifest = await generateManifest({
+        globs: ['**/*.js'],
+        exclude: ['my-element.js'],
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      // Should have fewer modules when excluding
+      assert.ok(manifest.modules.length < manifestWithoutExclude.modules.length || 
+                manifest.modules.length === 0, 
+                'Excluded file should reduce module count');
+      
+      // Should not have the excluded module
+      const hasExcludedModule = manifest.modules.some(m => m.path.includes('my-element.js'));
+      assert.ok(!hasExcludedModule, 'Excluded file should not be in manifest');
+    });
+
+    it('should support custom output directory', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+      const customOutdir = path.join(testOutputDir, 'custom-dir');
+      const relativeOutdir = path.relative(packagePath, customOutdir);
+
+      await generateManifest({
+        globs: ['**/*.js'],
+        outdir: relativeOutdir,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: true
+      });
+
+      const manifestPath = path.join(customOutdir, 'custom-elements.json');
+      assert.ok(fs.existsSync(manifestPath), 'Manifest should exist in custom directory');
+    });
+
+    it('should create output directory if it does not exist', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+      const nonExistentDir = path.join(testOutputDir, 'new', 'nested', 'dir');
+      const relativeOutdir = path.relative(packagePath, nonExistentDir);
+
+      await generateManifest({
+        globs: ['**/*.js'],
+        outdir: relativeOutdir,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: true
+      });
+
+      const manifestPath = path.join(nonExistentDir, 'custom-elements.json');
+      assert.ok(fs.existsSync(manifestPath), 'Manifest should exist in newly created directory');
+    });
+  });
+
+  describe('with config file path', ({ it }) => {
+    it('should load config from file path', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+      
+      // Create a temporary config file
+      const configPath = path.join(packagePath, 'custom-elements-manifest.config.js');
+      
+      const configContent = `export default {
+  globs: ['**/*.js'],
+  outdir: '.',
+  quiet: true,
+};`;
+      
+      fs.writeFileSync(configPath, configContent);
+
+      try {
+        const manifest = await generateManifest(configPath, {
+          cwd: packagePath,
+          write: false
+        });
+
+        assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+        assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+      } finally {
+        // Clean up the temporary config file
+        if (fs.existsSync(configPath)) {
+          fs.unlinkSync(configPath);
+        }
+      }
+    });
+  });
+
+  describe('framework plugins', ({ it }) => {
+    it('should support litelement option', async () => {
+      const packagePath = path.join(fixturesDir, '07-plugin-lit/package');
+      const fixturePath = path.join(fixturesDir, '07-plugin-lit/fixture/custom-elements.json');
+      
+      if (!fs.existsSync(packagePath)) {
+        // Skip if fixture doesn't exist
+        return;
+      }
+
+      const expectedManifest = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
+
+      const manifest = await generateManifest({
+        globs: ['**/*.js'],
+        litelement: true,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      delete manifest.readme;
+      delete expectedManifest.readme;
+
+      assert.deepEqual(manifest, expectedManifest);
+    });
+
+    it('should support stencil option', async () => {
+      const packagePath = path.join(fixturesDir, '08-plugin-stencil/package');
+      
+      if (!fs.existsSync(packagePath)) {
+        // Skip if fixture doesn't exist
+        return;
+      }
+
+      const manifest = await generateManifest({
+        globs: ['**/*.tsx'],
+        stencil: true,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+      assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+    });
+
+    it('should support fast option', async () => {
+      const packagePath = path.join(fixturesDir, '09-plugin-fast/package');
+      
+      if (!fs.existsSync(packagePath)) {
+        // Skip if fixture doesn't exist
+        return;
+      }
+
+      const manifest = await generateManifest({
+        globs: ['**/*.js'],
+        fast: true,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+      assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+    });
+
+    it('should support catalyst option', async () => {
+      const packagePath = path.join(fixturesDir, '10-plugin-catalyst/package');
+      
+      if (!fs.existsSync(packagePath)) {
+        // Skip if fixture doesn't exist
+        return;
+      }
+
+      const manifest = await generateManifest({
+        globs: ['**/*.ts'],
+        catalyst: true,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+      assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+    });
+  });
+
+  describe('custom plugins', ({ it }) => {
+    it('should support custom plugins', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+      
+      let pluginCalled = false;
+      const customPlugin = {
+        name: 'test-plugin',
+        initialize: () => {
+          pluginCalled = true;
+        }
+      };
+
+      await generateManifest({
+        globs: ['**/*.js'],
+        plugins: [customPlugin],
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.ok(pluginCalled, 'Custom plugin should be called');
+    });
+  });
+
+  describe('edge cases', ({ it }) => {
+    it('should handle empty config object', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+
+      const manifest = await generateManifest({}, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+      assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+    });
+
+    it('should handle undefined config', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+
+      const manifest = await generateManifest(undefined, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+      assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+    });
+
+    it('should use process.cwd() when cwd option is not provided', async () => {
+      // Save current directory
+      const originalCwd = process.cwd();
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+      
+      try {
+        // Change to package directory
+        process.chdir(packagePath);
+
+        const manifest = await generateManifest({
+          globs: ['**/*.js'],
+          quiet: true,
+        }, {
+          write: false
+        });
+
+        assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+        assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+      } finally {
+        // Restore original directory
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('should return manifest with correct schema version', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+
+      const manifest = await generateManifest({
+        globs: ['**/*.js'],
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.strictEqual(manifest.schemaVersion, '1.0.0', 'Schema version should be 1.0.0');
+    });
+  });
+
+  describe('dependencies option', ({ it }) => {
+    it('should handle dependencies option', async () => {
+      const packagePath = path.join(fixturesDir, '02-inheritance/04-external/package');
+      
+      if (!fs.existsSync(packagePath)) {
+        // Skip if fixture doesn't exist
+        return;
+      }
+
+      const manifest = await generateManifest({
+        globs: ['**/*.js'],
+        dependencies: true,
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.ok(manifest.schemaVersion, 'Manifest should have schemaVersion');
+      assert.ok(Array.isArray(manifest.modules), 'Manifest should have modules array');
+    });
+  });
+
+  describe('manifest structure', ({ it }) => {
+    it('should generate manifest with proper structure', async () => {
+      const packagePath = path.join(fixturesDir, '01-class/01-fields/package');
+
+      const manifest = await generateManifest({
+        globs: ['**/*.js'],
+        quiet: true,
+      }, {
+        cwd: packagePath,
+        write: false
+      });
+
+      assert.ok(manifest.schemaVersion, 'Should have schemaVersion');
+      assert.ok(typeof manifest.readme === 'string', 'Should have readme property');
+      assert.ok(Array.isArray(manifest.modules), 'Should have modules array');
+      
+      if (manifest.modules.length > 0) {
+        const module = manifest.modules[0];
+        assert.strictEqual(module.kind, 'javascript-module', 'Module should have correct kind');
+        assert.ok(module.path, 'Module should have path');
+        assert.ok(Array.isArray(module.declarations), 'Module should have declarations array');
+        assert.ok(Array.isArray(module.exports), 'Module should have exports array');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Right now, one of the challenges we have when using tools like Storybook is we have to run the CEM Analyzer and Storybook on separate processes at the same time in order for the CEM to be properly updated to then keep Storybook properly updated. Being able to run the analyzer as part of the build process would greatly simplify this process.

This PR includes:

- A way to programmatically generate a CEM
- A rollup plugin that can be used in Rollup, Vite, and Web Dev Server.