### PR TITLE
fix: prevent identifier extraction as event names, support custom Event classes

### DIFF
--- a/packages/analyzer/fixtures/05-events/02-subclassed-events/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/05-events/02-subclassed-events/fixture/custom-elements.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "method",
+              "name": "dispatchMyEvent"
+            },
+            {
+              "kind": "method",
+              "name": "dispatchAnotherEvent"
+            }
+          ],
+          "events": [
+            {
+              "name": "my-custom-event",
+              "type": {
+                "text": "MyCustomEvent"
+              }
+            },
+            {
+              "name": "another-event",
+              "type": {
+                "text": "AnotherEvent"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-element",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-element",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/05-events/02-subclassed-events/output.json
+++ b/packages/analyzer/fixtures/05-events/02-subclassed-events/output.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "method",
+              "name": "dispatchMyEvent"
+            },
+            {
+              "kind": "method",
+              "name": "dispatchAnotherEvent"
+            }
+          ],
+          "events": [
+            {
+              "name": "my-custom-event",
+              "type": {
+                "text": "MyCustomEvent"
+              }
+            },
+            {
+              "name": "another-event",
+              "type": {
+                "text": "AnotherEvent"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-element",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-element",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/05-events/02-subclassed-events/package/my-element.js
+++ b/packages/analyzer/fixtures/05-events/02-subclassed-events/package/my-element.js
@@ -1,0 +1,30 @@
+/**
+ * Subclassed event that extends Event
+ */
+class MyCustomEvent extends Event {
+  constructor(detail) {
+    super('my-custom-event', { bubbles: true, composed: true });
+    this.detail = detail;
+  }
+}
+
+/**
+ * Another subclassed event
+ */
+class AnotherEvent extends CustomEvent {
+  constructor(data) {
+    super('another-event', { detail: data });
+  }
+}
+
+class MyElement extends HTMLElement {
+  dispatchMyEvent() {
+    this.dispatchEvent(new MyCustomEvent({ foo: 'bar' }));
+  }
+
+  dispatchAnotherEvent() {
+    this.dispatchEvent(new AnotherEvent({ baz: 'qux' }));
+  }
+}
+
+customElements.define('my-element', MyElement);

--- a/packages/analyzer/fixtures/05-events/03-subclassed-events-with-args/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/05-events/03-subclassed-events-with-args/fixture/custom-elements.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "method",
+              "name": "updateData",
+              "parameters": [
+                {
+                  "name": "newValue"
+                },
+                {
+                  "name": "oldValue"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "updateStatus",
+              "parameters": [
+                {
+                  "name": "statusData"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "dispatchOldWay"
+            }
+          ],
+          "events": [
+            {
+              "name": "data-change",
+              "type": {
+                "text": "DataChangeEvent"
+              }
+            },
+            {
+              "name": "status-update",
+              "type": {
+                "text": "StatusEvent"
+              }
+            },
+            {
+              "name": "old-way-event",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-element",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-element",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/05-events/03-subclassed-events-with-args/output.json
+++ b/packages/analyzer/fixtures/05-events/03-subclassed-events-with-args/output.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "method",
+              "name": "updateData",
+              "parameters": [
+                {
+                  "name": "newValue"
+                },
+                {
+                  "name": "oldValue"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "updateStatus",
+              "parameters": [
+                {
+                  "name": "statusData"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "dispatchOldWay"
+            }
+          ],
+          "events": [
+            {
+              "name": "data-change",
+              "type": {
+                "text": "DataChangeEvent"
+              }
+            },
+            {
+              "name": "status-update",
+              "type": {
+                "text": "StatusEvent"
+              }
+            },
+            {
+              "name": "old-way-event",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "my-element",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-element",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/05-events/03-subclassed-events-with-args/package/my-element.js
+++ b/packages/analyzer/fixtures/05-events/03-subclassed-events-with-args/package/my-element.js
@@ -1,0 +1,44 @@
+/**
+ * Tests that identifiers passed to subclassed events are NOT extracted as event names
+ * This addresses GitHub issue #149:
+ * https://github.com/open-wc/custom-elements-manifest/issues/149
+ *
+ * The bug: When dispatching subclassed events like `new MyEvent(someArg)`,
+ * the analyzer incorrectly extracted 'someArg' as the event name.
+ * It should instead extract the event name from the super() call in MyEvent's constructor.
+ */
+class DataChangeEvent extends Event {
+  constructor(newValue, oldValue) {
+    super('data-change', { bubbles: true });
+    this.newValue = newValue;
+    this.oldValue = oldValue;
+  }
+}
+
+/**
+ * Subclassed event with object parameter
+ */
+class StatusEvent extends CustomEvent {
+  constructor(statusData) {
+    super('status-update', { detail: statusData });
+  }
+}
+
+class MyElement extends HTMLElement {
+  updateData(newValue, oldValue) {
+    // This should NOT extract 'newValue' as the event name
+    this.dispatchEvent(new DataChangeEvent(newValue, oldValue));
+  }
+
+  updateStatus(statusData) {
+    // This should NOT extract 'statusData' as the event name
+    this.dispatchEvent(new StatusEvent(statusData));
+  }
+
+  // For comparison: this is the old way that should still work
+  dispatchOldWay() {
+    this.dispatchEvent(new CustomEvent('old-way-event', { detail: {} }));
+  }
+}
+
+customElements.define('my-element', MyElement);

--- a/packages/analyzer/src/features/analyse-phase/creators/createClass.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/createClass.js
@@ -149,7 +149,7 @@ export function createClass(node, moduleDoc, context) {
      * In order to find `this.dispatchEvent` calls, we have to traverse a method's AST
      */
     if (ts.isMethodDeclaration(member)) {
-      eventsVisitor(member, classTemplate);
+      eventsVisitor(member, classTemplate, context);
     }
   });
 
@@ -165,7 +165,7 @@ export function createClass(node, moduleDoc, context) {
   return classTemplate;
 }
 
-function eventsVisitor(source, classTemplate) {
+function eventsVisitor(source, classTemplate, context) {
   visitNode(source);
 
   function visitNode(node) {
@@ -176,8 +176,26 @@ function eventsVisitor(source, classTemplate) {
         if (isDispatchEvent(node) && !hasIgnoreJSDoc(node.parent)) {
           node?.arguments?.forEach((arg) => {
             if (arg.kind === ts.SyntaxKind.NewExpression) {
-              /** e.g. `selected-changed` */
-              const eventName = arg?.arguments?.[0]?.text;
+              const eventClassName = arg.expression.text;
+              let eventName;
+
+              /**
+               * First, try to extract event name from a string literal argument
+               * e.g. `new Event('my-event')` or `new CustomEvent('my-event', {...})`
+               */
+              const firstArg = arg?.arguments?.[0];
+              if (firstArg && ts.isStringLiteral(firstArg)) {
+                eventName = firstArg.text;
+              }
+              /**
+               * If no string literal found, check if this is a custom Event class
+               * that we collected earlier, and use the event name from its super() call
+               * e.g. `new MyCustomEvent()` where MyCustomEvent extends Event and calls super('my-event')
+               */
+              else if (context?.eventClasses?.[eventClassName]) {
+                eventName = context.eventClasses[eventClassName];
+              }
+
               /**
                * Check if event already exists
                */
@@ -187,7 +205,7 @@ function eventsVisitor(source, classTemplate) {
                 let eventDoc = {
                   ...(eventName ? { name: eventName } : {}),
                   type: {
-                    text: arg.expression.text,
+                    text: eventClassName,
                   },
                 };
 

--- a/packages/analyzer/src/features/collect-phase/collect-event-classes.js
+++ b/packages/analyzer/src/features/collect-phase/collect-event-classes.js
@@ -1,0 +1,109 @@
+import ts from 'typescript';
+
+/**
+ * COLLECT-EVENT-CLASSES
+ *
+ * Collects custom Event class definitions and extracts the event name from the super() call.
+ * This allows us to properly infer event names when custom event classes are dispatched.
+ *
+ * @example
+ * class MyEvent extends Event {
+ *   constructor() {
+ *     super('my-event');
+ *   }
+ * }
+ *
+ * // Later:
+ * this.dispatchEvent(new MyEvent()); // Should infer name: 'my-event'
+ */
+export function collectEventClassesPlugin() {
+  const eventClasses = {};
+
+  return {
+    name: 'CORE - EVENT-CLASSES',
+    collectPhase({ts, node, context}) {
+      if (node.kind === ts.SyntaxKind.SourceFile) {
+        /**
+         * Create an empty object for each module we visit
+         */
+        if (!eventClasses[node.fileName]) {
+          eventClasses[node.fileName] = {};
+        }
+      }
+
+      /**
+       * Look for class declarations that extend Event or CustomEvent
+       */
+      if (ts.isClassDeclaration(node) && node.heritageClauses) {
+        const className = node.name?.getText();
+        if (!className) return;
+
+        // Check if class extends Event, CustomEvent, or other known event types
+        const extendsEventType = node.heritageClauses.some(clause => {
+          return clause.types.some(type => {
+            const typeName = type.expression.getText();
+            return ['Event', 'CustomEvent', 'KeyboardEvent', 'MouseEvent', 'FocusEvent',
+                    'InputEvent', 'PointerEvent', 'TouchEvent', 'WheelEvent'].includes(typeName);
+          });
+        });
+
+        if (!extendsEventType) return;
+
+        // Find the constructor
+        const constructor = node.members.find(member =>
+          ts.isConstructorDeclaration(member)
+        );
+
+        if (!constructor?.body) return;
+
+        // Find the super() call in the constructor
+        const superCall = findSuperCall(constructor.body);
+        if (!superCall) return;
+
+        // Extract the event name from the first argument to super()
+        const firstArg = superCall.arguments?.[0];
+        if (firstArg && ts.isStringLiteral(firstArg)) {
+          const fileName = node.getSourceFile().fileName;
+          if (!eventClasses[fileName]) {
+            eventClasses[fileName] = {};
+          }
+          eventClasses[fileName][className] = firstArg.text;
+
+          if (context.dev) {
+            console.log(`[EVENT-CLASSES] Found event class: ${className} -> '${firstArg.text}'`);
+          }
+        }
+      }
+    },
+    analyzePhase({ts, node, context}) {
+      if (node.kind === ts.SyntaxKind.SourceFile) {
+        /**
+         * Make the event classes mapping available on the context object for the current module
+         */
+        context.eventClasses = eventClasses[node.fileName] || {};
+      }
+    },
+    packageLinkPhase({context}) {
+      /** Reset */
+      context.eventClasses = {};
+    }
+  };
+}
+
+/**
+ * Recursively search for a super() call in a constructor body
+ */
+function findSuperCall(node) {
+  if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.SuperKeyword) {
+    return node;
+  }
+
+  let result = null;
+  ts.forEachChild(node, child => {
+    if (!result) {
+      result = findSuperCall(child);
+    }
+  });
+
+  return result;
+}

--- a/packages/analyzer/src/features/index.js
+++ b/packages/analyzer/src/features/index.js
@@ -2,6 +2,7 @@
  * COLLECT
  */
 import { collectImportsPlugin } from './collect-phase/collect-imports.js';
+import { collectEventClassesPlugin } from './collect-phase/collect-event-classes.js';
 
 /**
  * ANALYSE
@@ -47,6 +48,7 @@ import { litPlugin } from './framework-plugins/lit/lit.js';
 export const FEATURES = [
   /** COLLECT */
   collectImportsPlugin(),
+  collectEventClassesPlugin(),
   
   /** ANALYSE */
   exportsPlugin(),


### PR DESCRIPTION
Fixes #149

1. The analyzer incorrectly extracted identifiers as event names when dispatching custom event classes (e.g., extracting "someArg" from `new MyEvent(someArg)`).
2. Now parses custom Event class constructors to extract the actual event name from the `super()` call.