### PR TITLE
feat: fix #150 - JSDoc comments from mixin class ignored

### DIFF
--- a/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/fixture/custom-elements.json
@@ -1,0 +1,206 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "foo-mixin.js",
+      "declarations": [
+        {
+          "kind": "mixin",
+          "description": "",
+          "name": "FooMixin",
+          "members": [
+            {
+              "kind": "field",
+              "name": "__foo",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "foo"
+            }
+          ],
+          "attributes": [
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "the foo attribute",
+              "name": "foo"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "klass"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FooMixin",
+          "declaration": {
+            "name": "FooMixin",
+            "module": "foo-mixin.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "method",
+              "name": "classMethod"
+            },
+            {
+              "kind": "field",
+              "name": "__foo",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "FooMixin",
+                "module": "foo-mixin.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "foo",
+              "inheritedFrom": {
+                "name": "FooMixin",
+                "module": "foo-mixin.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "renderSomeSlot",
+              "inheritedFrom": {
+                "name": "SlotMixin",
+                "module": "slot-mixin.js"
+              }
+            }
+          ],
+          "events": [
+            {
+              "name": "class-event",
+              "type": {
+                "text": "Event"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "class-attr"
+            },
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "the foo attribute",
+              "name": "foo",
+              "inheritedFrom": {
+                "name": "FooMixin",
+                "module": "foo-mixin.js"
+              }
+            }
+          ],
+          "mixins": [
+            {
+              "name": "FooMixin",
+              "module": "/foo-mixin.js"
+            },
+            {
+              "name": "SlotMixin",
+              "module": "/slot-mixin.js"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "customElement": true,
+          "slots": [
+            {
+              "description": "the foo slot description",
+              "name": "foo",
+              "inheritedFrom": {
+                "name": "SlotMixin",
+                "module": "slot-mixin.js"
+              }
+            }
+          ],
+          "cssParts": [
+            {
+              "description": "the header container",
+              "name": "header",
+              "inheritedFrom": {
+                "name": "SlotMixin",
+                "module": "slot-mixin.js"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "MyElement",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "slot-mixin.js",
+      "declarations": [
+        {
+          "kind": "mixin",
+          "description": "",
+          "name": "SlotMixin",
+          "cssParts": [
+            {
+              "description": "the header container",
+              "name": "header"
+            }
+          ],
+          "slots": [
+            {
+              "description": "the foo slot description",
+              "name": "foo"
+            }
+          ],
+          "members": [
+            {
+              "kind": "method",
+              "name": "renderSomeSlot"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "superClass"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "SlotMixin",
+          "declaration": {
+            "name": "SlotMixin",
+            "module": "slot-mixin.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/output.json
+++ b/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/output.json
@@ -1,0 +1,206 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "foo-mixin.js",
+      "declarations": [
+        {
+          "kind": "mixin",
+          "description": "",
+          "name": "FooMixin",
+          "members": [
+            {
+              "kind": "field",
+              "name": "__foo",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "foo"
+            }
+          ],
+          "attributes": [
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "the foo attribute",
+              "name": "foo"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "klass"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FooMixin",
+          "declaration": {
+            "name": "FooMixin",
+            "module": "foo-mixin.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MyElement",
+          "members": [
+            {
+              "kind": "method",
+              "name": "classMethod"
+            },
+            {
+              "kind": "field",
+              "name": "__foo",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "FooMixin",
+                "module": "foo-mixin.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "foo",
+              "inheritedFrom": {
+                "name": "FooMixin",
+                "module": "foo-mixin.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "renderSomeSlot",
+              "inheritedFrom": {
+                "name": "SlotMixin",
+                "module": "slot-mixin.js"
+              }
+            }
+          ],
+          "events": [
+            {
+              "name": "class-event",
+              "type": {
+                "text": "Event"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "class-attr"
+            },
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "the foo attribute",
+              "name": "foo",
+              "inheritedFrom": {
+                "name": "FooMixin",
+                "module": "foo-mixin.js"
+              }
+            }
+          ],
+          "mixins": [
+            {
+              "name": "FooMixin",
+              "module": "/foo-mixin.js"
+            },
+            {
+              "name": "SlotMixin",
+              "module": "/slot-mixin.js"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "customElement": true,
+          "slots": [
+            {
+              "description": "the foo slot description",
+              "name": "foo",
+              "inheritedFrom": {
+                "name": "SlotMixin",
+                "module": "slot-mixin.js"
+              }
+            }
+          ],
+          "cssParts": [
+            {
+              "description": "the header container",
+              "name": "header",
+              "inheritedFrom": {
+                "name": "SlotMixin",
+                "module": "slot-mixin.js"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "MyElement",
+          "declaration": {
+            "name": "MyElement",
+            "module": "my-element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "slot-mixin.js",
+      "declarations": [
+        {
+          "kind": "mixin",
+          "description": "",
+          "name": "SlotMixin",
+          "cssParts": [
+            {
+              "description": "the header container",
+              "name": "header"
+            }
+          ],
+          "slots": [
+            {
+              "description": "the foo slot description",
+              "name": "foo"
+            }
+          ],
+          "members": [
+            {
+              "kind": "method",
+              "name": "renderSomeSlot"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "superClass"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "SlotMixin",
+          "declaration": {
+            "name": "SlotMixin",
+            "module": "slot-mixin.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/package/foo-mixin.js
+++ b/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/package/foo-mixin.js
@@ -1,0 +1,21 @@
+/**
+ *
+ * @attribute {boolean} foo - the foo attribute
+ * @cssProp
+ *
+ * @constructor
+ */
+export const FooMixin = klass => class extends klass {
+  /**
+   * @private
+   */
+  __foo;
+
+  get foo() {
+    return this.__foo;
+  }
+
+  set foo(v) {
+    this.__foo = v;
+  }
+}

--- a/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/package/my-element.js
+++ b/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/package/my-element.js
@@ -1,0 +1,10 @@
+import {FooMixin} from "./foo-mixin.js";
+import {SlotMixin} from "./slot-mixin.js";
+
+export class MyElement extends FooMixin(SlotMixin(HTMLElement)) {
+  static observedAttributes = ['class-attr'];
+
+  classMethod() {
+    this.dispatchEvent(new Event('class-event'))
+  }
+}

--- a/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/package/slot-mixin.js
+++ b/packages/analyzer/fixtures/02-inheritance/06-mixin-jsdoc/package/slot-mixin.js
@@ -1,0 +1,14 @@
+export function SlotMixin(superClass) {
+  /**
+   * @slot foo - the foo slot description
+   *
+   * @part header - the header container
+   */
+  class SlotElement extends superClass {
+    renderSomeSlot() {
+      return '';
+    }
+  }
+
+  return SlotElement;
+}

--- a/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
+++ b/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
@@ -1,6 +1,8 @@
 import { parse } from 'comment-parser';
 import { handleJsDocType, normalizeDescription } from '../../utils/jsdoc.js';
 import { has, safe } from '../../utils/index.js';
+import { extractMixinNodes, isMixin } from '../../utils/mixins.js';
+import { handleName } from './creators/createMixin.js';
 
 /**
  * CLASS-JSDOC
@@ -12,128 +14,140 @@ export function classJsDocPlugin() {
     name: 'CORE - CLASS-JSDOC',
     analyzePhase({ts, node, moduleDoc}){
       switch (node.kind) {
+        case ts.SyntaxKind.VariableStatement:
+        case ts.SyntaxKind.FunctionDeclaration:
+          if(isMixin(node)) {
+            const { mixinFunction, mixinClass } = extractMixinNodes(node);
+            const { name } = handleName({}, mixinFunction);
+            const classDoc = moduleDoc?.declarations?.find(declaration => declaration.name === name);
+
+            mixinClass?.jsDoc?.forEach(jsDoc => handleJsDocParsing(jsDoc, classDoc));
+            node?.jsDoc?.forEach(jsDoc => handleJsDocParsing(jsDoc, classDoc));
+          }
+          break;
+
         case ts.SyntaxKind.ClassDeclaration:
           const className = node?.name?.getText();
           const classDoc = moduleDoc?.declarations?.find(declaration => declaration.name === className);
 
-          /**
-           * Because we use a bunch of 'non-standard' JSDoc annotations, TS doesn't recognize most of them.
-           * Instead we use `comment-parser` to parse the JSDoc.
-           *
-           * Loops through each JSDoc (yes, there can be multiple) above a class, and parses every JSDoc annotation
-           *
-           * Checks to see if the item is already in the classDoc, and if so merge and overwrite (JSDoc takes precedence)
-           */
-          node?.jsDoc?.forEach(jsDoc => {
-            const parsed = parse(jsDoc?.getFullText());
-            parsed?.forEach(parsedJsDoc => {
-
-              /**
-               * If any of the tags is a `@typedef`, we ignore it; this JSDoc comment may be above a class,
-               * it probably doesnt _belong_ to the class, but something else in the file
-               */
-              if(parsedJsDoc?.tags?.some(tag => tag?.tag === 'typedef')) return;
-
-              parsedJsDoc?.tags?.forEach(jsDoc => {
-                switch(jsDoc.tag) {
-                  case 'attr':
-                  case 'attribute':
-                    const attributeAlreadyExists = classDoc?.attributes?.find(attr => attr.name === jsDoc.name);
-                    let attributeDoc = attributeAlreadyExists || {};
-                    attributeDoc = handleClassJsDoc(attributeDoc, jsDoc);
-                    if(!attributeAlreadyExists) {
-                      classDoc.attributes.push(attributeDoc);
-                    }
-                    break;
-                  case 'prop':
-                  case 'property':
-                    const fieldAlreadyExists = classDoc?.members?.find(member => member.name === jsDoc.name);
-                    let fieldDoc = fieldAlreadyExists || {};
-                    fieldDoc = handleClassJsDoc(fieldDoc, jsDoc);
-                    fieldDoc.kind = 'field';
-                    if(!fieldAlreadyExists) {
-                      classDoc.members.push(fieldDoc);
-                    }
-                    break;
-                  case 'fires':
-                  case 'event':
-                    const eventAlreadyExists = classDoc?.events?.find(event => event.name === jsDoc.name);
-                    let eventDoc = eventAlreadyExists || {};
-                    eventDoc = handleClassJsDoc(eventDoc, jsDoc);
-                    delete eventDoc.privacy;
-                    if(!eventAlreadyExists) {
-                      classDoc.events.push(eventDoc);
-                    }
-                    break;
-                  case 'csspart':
-                  case 'part':
-                    let cssPartDoc = {};
-                    cssPartDoc = handleClassJsDoc(cssPartDoc, jsDoc);
-                    classDoc.cssParts.push(cssPartDoc);
-                    break;
-                  case 'cssprop':
-                  case 'cssproperty':
-                    let cssPropertyDoc = {};
-                    cssPropertyDoc = handleClassJsDoc(cssPropertyDoc, jsDoc);
-                    classDoc.cssProperties.push(cssPropertyDoc);
-                    break;
-                  case 'slot':
-                    let slotDoc = {};
-                    slotDoc = handleClassJsDoc(slotDoc, jsDoc);
-                    classDoc.slots.push(slotDoc);
-                    break;
-                  case 'tag':
-                  case 'tagname':
-                  case 'element':
-                  case 'customElement':
-                  case 'customelement':
-                    classDoc.tagName = jsDoc?.name || '';
-                    classDoc.customElement = true;
-                    break;
-                  case 'cssState':
-                  case 'cssstate':
-                    let statePropertyDoc = {};
-                    statePropertyDoc = handleClassJsDoc(statePropertyDoc, jsDoc);
-                    classDoc.cssStates.push(statePropertyDoc);
-                    break;
-                  case 'deprecated':
-                    classDoc.deprecated = jsDoc?.name ? `${jsDoc.name} ${jsDoc?.description}`.trim() : "true";
-                    break;
-                }
-              })
-            });
-
-            /**
-             * Description
-             */
-            if(jsDoc?.comment) {
-              if(has(jsDoc?.comment)) {
-                classDoc.description = jsDoc.comment.map(com => `${safe(() => com?.name?.getText()) ?? ''}${com.text}`).join('');
-              } else {
-                classDoc.description = normalizeDescription(jsDoc.comment);
-              }
-            }
-
-            /**
-             * Comment-parse doesn't handle annotations with only a description correctly, for example:
-             * @summary foo bar
-             * will output only 'bar' as the description.
-             *
-             * Instead, we use TS for this JSDoc annotation.
-             */
-            jsDoc?.tags?.forEach(tag => {
-              switch(safe(() => tag?.tagName?.getText())) {
-                case 'summary':
-                  classDoc.summary = tag?.comment;
-                  break;
-              }
-            });
-          });
-
+          node?.jsDoc?.forEach(jsDoc => handleJsDocParsing(jsDoc, classDoc));
           break;
       }
     }
   }
+}
+
+/**
+ * Because we use a bunch of 'non-standard' JSDoc annotations, TS doesn't recognize most of them.
+ * Instead we use `comment-parser` to parse the JSDoc.
+ *
+ * Loops through each JSDoc (yes, there can be multiple) above a class, and parses every JSDoc annotation
+ *
+ * Checks to see if the item is already in the classDoc, and if so merge and overwrite (JSDoc takes precedence)
+ */
+function handleJsDocParsing(jsDoc, classDoc) {
+  const parsed = parse(jsDoc?.getFullText());
+  parsed?.forEach(parsedJsDoc => {
+    /**
+     * If any of the tags is a `@typedef`, we ignore it; this JSDoc comment may be above a class,
+     * it probably doesnt _belong_ to the class, but something else in the file
+     */
+    if(parsedJsDoc?.tags?.some(tag => tag?.tag === 'typedef')) return;
+
+    parsedJsDoc?.tags?.forEach(jsDoc => {
+      switch(jsDoc.tag) {
+        case 'attr':
+        case 'attribute':
+          const attributeAlreadyExists = classDoc?.attributes?.find(attr => attr.name === jsDoc.name);
+          let attributeDoc = attributeAlreadyExists || {};
+          attributeDoc = handleClassJsDoc(attributeDoc, jsDoc);
+          if(!attributeAlreadyExists) {
+            classDoc.attributes.push(attributeDoc);
+          }
+          break;
+        case 'prop':
+        case 'property':
+          const fieldAlreadyExists = classDoc?.members?.find(member => member.name === jsDoc.name);
+          let fieldDoc = fieldAlreadyExists || {};
+          fieldDoc = handleClassJsDoc(fieldDoc, jsDoc);
+          fieldDoc.kind = 'field';
+          if(!fieldAlreadyExists) {
+            classDoc.members.push(fieldDoc);
+          }
+          break;
+        case 'fires':
+        case 'event':
+          const eventAlreadyExists = classDoc?.events?.find(event => event.name === jsDoc.name);
+          let eventDoc = eventAlreadyExists || {};
+          eventDoc = handleClassJsDoc(eventDoc, jsDoc);
+          delete eventDoc.privacy;
+          if(!eventAlreadyExists) {
+            classDoc.events.push(eventDoc);
+          }
+          break;
+        case 'csspart':
+        case 'part':
+          let cssPartDoc = {};
+          cssPartDoc = handleClassJsDoc(cssPartDoc, jsDoc);
+          classDoc.cssParts.push(cssPartDoc);
+          break;
+        case 'cssprop':
+        case 'cssproperty':
+          let cssPropertyDoc = {};
+          cssPropertyDoc = handleClassJsDoc(cssPropertyDoc, jsDoc);
+          classDoc.cssProperties.push(cssPropertyDoc);
+          break;
+        case 'slot':
+          let slotDoc = {};
+          slotDoc = handleClassJsDoc(slotDoc, jsDoc);
+          classDoc.slots.push(slotDoc);
+          break;
+        case 'tag':
+        case 'tagname':
+        case 'element':
+        case 'customElement':
+        case 'customelement':
+          classDoc.tagName = jsDoc?.name || '';
+          classDoc.customElement = true;
+          break;
+        case 'cssState':
+        case 'cssstate':
+          let statePropertyDoc = {};
+          statePropertyDoc = handleClassJsDoc(statePropertyDoc, jsDoc);
+          classDoc.cssStates.push(statePropertyDoc);
+          break;
+        case 'deprecated':
+          classDoc.deprecated = jsDoc?.name ? `${jsDoc.name} ${jsDoc?.description}`.trim() : "true";
+          break;
+      }
+    })
+  });
+
+  /**
+   * Description
+   */
+  if(jsDoc?.comment) {
+    if(has(jsDoc?.comment)) {
+      classDoc.description = jsDoc.comment.map(com => `${safe(() => com?.name?.getText()) ?? ''}${com.text}`).join('');
+    } else {
+      classDoc.description = normalizeDescription(jsDoc.comment);
+    }
+  }
+
+  /**
+   * Comment-parse doesn't handle annotations with only a description correctly, for example:
+   * @summary foo bar
+   * will output only 'bar' as the description.
+   *
+   * Instead, we use TS for this JSDoc annotation.
+   */
+  jsDoc?.tags?.forEach(tag => {
+    switch(safe(() => tag?.tagName?.getText())) {
+      case 'summary':
+        classDoc.summary = tag?.comment;
+        break;
+    }
+  });
 }
 
 function handleClassJsDoc(doc, tag) {


### PR DESCRIPTION
Fix #150 

Retrieve information from JSDoc when using mixins.

```js
export function SlotMixin(superClass) {
  /**
   * @slot foo - i was hoping CEM would pick up on this, so i could document the slot just once, on the mixin.
   */
  class SlotElement extends superClass {
    renderSomeSlot() {
      return html`<slot name="foo"></slot>`;
    }
  }

  return SlotElement;
}
```