### PR TITLE
fix: normalize all JSDoc comments

### DIFF
--- a/packages/analyzer/fixtures/06-jsdoc/ignore-internal/fixture/custom-elements.json
+++ b/packages/analyzer/fixtures/06-jsdoc/ignore-internal/fixture/custom-elements.json
@@ -56,6 +56,11 @@
               "kind": "method",
               "name": "imDeprecatedWithReason",
               "deprecated": "the reason for the deprecation."
+            },
+            {
+              "kind": "method",
+              "name": "imDeprecatedWithLinkInReason",
+              "deprecated": "use somethingElse instead."
             }
           ],
           "superclass": {

--- a/packages/analyzer/fixtures/06-jsdoc/ignore-internal/output.json
+++ b/packages/analyzer/fixtures/06-jsdoc/ignore-internal/output.json
@@ -56,6 +56,11 @@
               "kind": "method",
               "name": "imDeprecatedWithReason",
               "deprecated": "the reason for the deprecation."
+            },
+            {
+              "kind": "method",
+              "name": "imDeprecatedWithLinkInReason",
+              "deprecated": "use somethingElse instead."
             }
           ],
           "superclass": {

--- a/packages/analyzer/fixtures/06-jsdoc/ignore-internal/package/my-element.js
+++ b/packages/analyzer/fixtures/06-jsdoc/ignore-internal/package/my-element.js
@@ -59,6 +59,11 @@ export class IncludeMe extends HTMLElement {
   
   }
 
+  /** @deprecated use {@link somethingElse} instead. */
+  imDeprecatedWithLinkInReason() {
+
+  }
+
   /** @internal */
   hideMe() {
     return '🙈'

--- a/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
+++ b/packages/analyzer/src/features/analyse-phase/class-jsdoc.js
@@ -1,5 +1,5 @@
 import { parse } from 'comment-parser';
-import { handleJsDocType, normalizeDescription } from '../../utils/jsdoc.js';
+import { handleJsDocType, normalizeComment, normalizeDescription } from '../../utils/jsdoc.js';
 import { has, safe } from '../../utils/index.js';
 
 /**
@@ -107,11 +107,7 @@ export function classJsDocPlugin() {
              * Description
              */
             if(jsDoc?.comment) {
-              if(has(jsDoc?.comment)) {
-                classDoc.description = jsDoc.comment.map(com => `${safe(() => com?.name?.getText()) ?? ''}${com.text}`).join('');
-              } else {
-                classDoc.description = normalizeDescription(jsDoc.comment);
-              }
+              classDoc.description = normalizeDescription(jsDoc.comment);
             }
 
             /**
@@ -124,7 +120,7 @@ export function classJsDocPlugin() {
             jsDoc?.tags?.forEach(tag => {
               switch(safe(() => tag?.tagName?.getText())) {
                 case 'summary':
-                  classDoc.summary = tag?.comment;
+                  classDoc.summary = normalizeComment(tag?.comment);
                   break;
               }
             });

--- a/packages/analyzer/src/features/analyse-phase/creators/handlers.js
+++ b/packages/analyzer/src/features/analyse-phase/creators/handlers.js
@@ -2,7 +2,7 @@ import ts from 'typescript';
 import { parse } from 'comment-parser';
 
 import { has, resolveModuleOrPackageSpecifier, safe } from '../../../utils/index.js';
-import { handleJsDocType, normalizeDescription } from '../../../utils/jsdoc.js';
+import { handleJsDocType, normalizeComment, normalizeDescription } from '../../../utils/jsdoc.js';
 import { isWellKnownType } from '../../../utils/ast-helpers.js';
 
 /**
@@ -47,11 +47,7 @@ export function handleModifiers(doc, node) {
 export function handleJsDoc(doc, node) {
   node?.jsDoc?.forEach(jsDocComment => {
     if(jsDocComment?.comment) {
-      if(has(jsDocComment?.comment)) {
-        doc.description = jsDocComment.comment.map(com => `${safe(() => com?.name?.getText()) ?? ''}${com.text}`).join('');
-      } else {
-        doc.description = normalizeDescription(jsDocComment.comment);
-      }
+      doc.description = normalizeDescription(jsDocComment.comment);
     }
 
     jsDocComment?.tags?.forEach(tag => {
@@ -120,17 +116,17 @@ export function handleJsDoc(doc, node) {
 
       /** @summary */
       if(safe(() => tag?.tagName?.getText()) === 'summary') {
-        doc.summary = tag.comment;
+        doc.summary = normalizeComment(tag.comment);
       }
 
       /** @deprecated */
       if(safe(() => tag?.tagName?.getText()) === 'deprecated') {
-        doc.deprecated = tag.comment || "true";
+        doc.deprecated = normalizeComment(tag.comment) || "true";
       }
 
       /** @default */
       if (safe(() => tag?.tagName?.getText()) === 'default' && doc?.kind === 'field') {
-        doc.default ??= tag.comment;
+        doc.default ??= normalizeComment(tag.comment);
       }
 
       /**

--- a/packages/analyzer/src/utils/jsdoc.js
+++ b/packages/analyzer/src/utils/jsdoc.js
@@ -1,3 +1,5 @@
+import { safe } from "./index.js";
+
 /**
  * UTILITIES RELATED TO JSDOC
  */
@@ -6,10 +8,16 @@ export function handleJsDocType(type) {
   return type?.replace(/(import\(.+?\).)/g, '') || '';
 }
 
-export function normalizeDescription(desc) {
-  if (Array.isArray(desc)) {
-    desc = desc.reduce((prev, curr) => prev += curr.getText(), '');
+export function normalizeComment(comment) {
+  if (Array.isArray(comment)) {
+    return comment.map(com => `${safe(() => com?.name?.getText()) ?? ''}${com.text}`).join('');
+  } else {
+    return comment;
   }
+}
+
+export function normalizeDescription(desc) {
+  desc = normalizeComment(desc);
 
   if (typeof desc === 'string' && desc?.startsWith('- ')) {
     desc = desc.slice(2);


### PR DESCRIPTION
Any [`JSDocTag`'s comment](https://github.com/microsoft/TypeScript/blob/v6.0.3/src/compiler/types.ts#L3961) can hold either a plain `string` or a `NodeArray<JSDocComment>`. We need to always normalize these to a plain string, otherwise the generated manifest would still contain references to TypeScript nodes and source files which [cannot be serialized to JSON](https://github.com/open-wc/custom-elements-manifest/blob/161fa8c9fb596704b45eaf16f2fbdc014255d108/packages/analyzer/src/utils/cli-helpers.js#L155).