### PR TITLE
Add newly-publish plugins to the plugin list

### DIFF
--- a/docs/analyzer/plugins/intro.md
+++ b/docs/analyzer/plugins/intro.md
@@ -56,6 +56,7 @@ export default {
 | [cem-plugin-readonly](https://www.npmjs.com/package/cem-plugin-readonly) | plugin to handle read-only class members |
 | [cem-plugin-type-descriptions-markdown](https://www.npmjs.com/package/cem-plugin-type-descriptions-markdown) | plugin to add markdown type documentation to manifest member descriptions |
 | [cem-plugin-wrec](https://www.npmjs.com/package/cem-plugin-wrec)                                                    | plugin to handle [wrec](https://www.npmjs.com/package/wrec) web components |
+| [cem-plugin-svelte](https://www.npmjs.com/package/cem-plugin-svelte) | plugin to handle [Svelte custom elements](https://svelte.dev/docs/svelte/custom-elements) |
 | [custom-element-jet-brains-integration](https://www.npmjs.com/package/custom-element-jet-brains-integration) | a mapper to take the information captured in the CEM and generate the appropriate `web-types.json` file for [JetBrains IDEs](https://www.jetbrains.com/) |
 | [custom-element-jsx-integration](https://www.npmjs.com/package/custom-element-jsx-integration) | a custom type generator to convert the CEM data into usable types to integrate custom elements into _non-React_ projects that use JSX templates |
 | [custom-element-lazy-loader](https://www.npmjs.com/package/custom-element-lazy-loader) | Create a single entry point to lazy-load your custom elements/web components as needed! |

--- a/docs/analyzer/plugins/intro.md
+++ b/docs/analyzer/plugins/intro.md
@@ -57,6 +57,7 @@ export default {
 | [cem-plugin-type-descriptions-markdown](https://www.npmjs.com/package/cem-plugin-type-descriptions-markdown) | plugin to add markdown type documentation to manifest member descriptions |
 | [cem-plugin-wrec](https://www.npmjs.com/package/cem-plugin-wrec)                                                    | plugin to handle [wrec](https://www.npmjs.com/package/wrec) web components |
 | [cem-plugin-svelte](https://www.npmjs.com/package/cem-plugin-svelte) | plugin to handle [Svelte custom elements](https://svelte.dev/docs/svelte/custom-elements) |
+| [cem-plugin-dts](https://www.npmjs.com/package/cem-plugin-dts) | plugin to generate `HTMLElement` TypeScript interfaces from your Custom Elements Manifest |
 | [custom-element-jet-brains-integration](https://www.npmjs.com/package/custom-element-jet-brains-integration) | a mapper to take the information captured in the CEM and generate the appropriate `web-types.json` file for [JetBrains IDEs](https://www.jetbrains.com/) |
 | [custom-element-jsx-integration](https://www.npmjs.com/package/custom-element-jsx-integration) | a custom type generator to convert the CEM data into usable types to integrate custom elements into _non-React_ projects that use JSX templates |
 | [custom-element-lazy-loader](https://www.npmjs.com/package/custom-element-lazy-loader) | Create a single entry point to lazy-load your custom elements/web components as needed! |


### PR DESCRIPTION
I just authored a pair of CEM Analyzer plugins that I'd love to add to the documentation site!

- [`cem-plugin-svelte`](https://www.npmjs.com/package/cem-plugin-svelte) supports parsing Svelte files to add them to a Custom Elements Manifest
- [`cem-plugin-dts`](https://www.npmjs.com/package/cem-plugin-dts) generates `.d.ts` files containing `HTMLElement` interfaces for the Custom Elements described by a manifest

The two are built to work together to provide all of the type information that consumers would want when authoring custom elements using Svelte, which can compile components to Custom Elements but does not handle any of the type-related tooling that you'd want to offer as well. An example project configured to use both can be found [here](https://github.com/alexlafroscia/custom-elements-playground/blob/74190251fd7aae5cc7b3811e6cf1406339fbe253/definitions/svelte-vite/custom-elements-manifest.config.js)!