### PR TITLE
fix: ignore nested node_modules by default

### DIFF
--- a/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/monorepo/packages/to-be-analyzed-pkg/nested/node_modules/leaky-pkg/leaky-element.js
+++ b/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/monorepo/packages/to-be-analyzed-pkg/nested/node_modules/leaky-pkg/leaky-element.js
@@ -1,0 +1,7 @@
+// Regression guard for nested `node_modules` exclusion.
+//
+// The recursive pattern `!**/node_modules/**` should exclude it.
+// If this element ever appears in the output again,
+// the node_modules ignore has regressed.
+class LeakyElement extends HTMLElement {}
+customElements.define('leaky-element', LeakyElement);

--- a/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/monorepo/packages/to-be-analyzed-pkg/nested/node_modules/leaky-pkg/package.json
+++ b/packages/analyzer/fixtures/02-inheritance/05-external-in-monorepo/monorepo/packages/to-be-analyzed-pkg/nested/node_modules/leaky-pkg/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "leaky-pkg",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "leaky-element.js"
+}

--- a/packages/analyzer/src/utils/cli-helpers.js
+++ b/packages/analyzer/src/utils/cli-helpers.js
@@ -9,8 +9,8 @@ const require = createRequire(import.meta.url);
 const { version } = require("../../package.json");
 
 const IGNORE = [
-  "!node_modules/**/*.*",
-  "!bower_components/**/*.*",
+  "!**/node_modules/**",
+  "!**/bower_components/**",
   "!**/*.test.{js,ts}",
   "!**/*.suite.{js,ts}",
   "!**/*.config.{js,ts}",


### PR DESCRIPTION
👋 Hello! Encountered an `analyze` run which slowed into an apparent hang caused by a monorepo/workspaces with nested `node_modules` directory, and their modules leaked into the manifest.

I saw there's a stale PR #258 that's quite inactive so I opened an unsolicited duplicate (apologies!) -- I carried the first PR's approach forward and applied the pattern to bower components as well. I do think the additional fixtures here should be enough to cover possible regression.

fixes #256 